### PR TITLE
Add termination support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,4 @@ Initial release, which includes the following features:
 - Orchestrations and activities
 - Durable timers
 - Sub-orchestrations
-
+- Suspend, resume, and terminate client operations

--- a/README.md
+++ b/README.md
@@ -117,9 +117,13 @@ Orchestrations can start child orchestrations using the `call_sub_orchestrator` 
 
 Orchestrations can wait for external events using the `wait_for_external_event` API. External events are useful for implementing human interaction patterns, such as waiting for a user to approve an order before continuing.
 
-### Suspend and resume
+### Continue-as-new (TODO)
 
-Orchestrations can be suspended using the `suspend_orchestration` client API and will remain suspended until resumed using the `resume_orchestration` client API. A suspended orchestration will stop processing new events, but will continue to buffer any that happen to arrive until resumed, ensuring that no data is lost.
+Orchestrations can be continued as new using the `continue_as_new` API. This API allows an orchestration to restart itself from scratch, optionally with a new input.
+
+### Suspend, resume, and terminate
+
+Orchestrations can be suspended using the `suspend_orchestration` client API and will remain suspended until resumed using the `resume_orchestration` client API. A suspended orchestration will stop processing new events, but will continue to buffer any that happen to arrive until resumed, ensuring that no data is lost. An orchestration can also be terminated using the `terminate_orchestration` client API. Terminated orchestrations will stop processing new events and will discard any buffered events.
 
 ### Retry policies (TODO)
 

--- a/durabletask/client.py
+++ b/durabletask/client.py
@@ -161,8 +161,14 @@ class TaskHubGrpcClient:
         self._logger.info(f"Raising event '{event_name}' for instance '{instance_id}'.")
         self._stub.RaiseEvent(req)
 
-    def terminate_orchestration(self):
-        raise NotImplementedError()
+    def terminate_orchestration(self, instance_id: str, *,
+                                output: Any | None = None):
+        req = pb.TerminateRequest(
+            instanceId=instance_id,
+            output=wrappers_pb2.StringValue(value=shared.to_json(output)) if output else None)
+
+        self._logger.info(f"Terminating instance '{instance_id}'.")
+        self._stub.TerminateInstance(req)
 
     def suspend_orchestration(self, instance_id: str):
         req = pb.SuspendRequest(instanceId=instance_id)

--- a/durabletask/internal/helpers.py
+++ b/durabletask/internal/helpers.py
@@ -139,6 +139,16 @@ def new_resume_event() -> pb.HistoryEvent:
     )
 
 
+def new_terminated_event(*, encoded_output: str | None = None) -> pb.HistoryEvent:
+    return pb.HistoryEvent(
+        eventId=-1,
+        timestamp=timestamp_pb2.Timestamp(),
+        executionTerminated=pb.ExecutionTerminatedEvent(
+            input=get_string_value(encoded_output)
+        )
+    )
+
+
 def get_string_value(val: str | None) -> wrappers_pb2.StringValue | None:
     if val is None:
         return None


### PR DESCRIPTION
This PR enables clients to send terminate requests and enables the worker to correctly process terminate events.

This PR also contains some new runtime validations to help prevent certain types of usage errors.