### PR TITLE
Add continue_as_new orchestration API

### DIFF
--- a/durabletask/internal/helpers.py
+++ b/durabletask/internal/helpers.py
@@ -3,7 +3,7 @@
 
 import traceback
 from datetime import datetime
-from typing import Union
+from typing import List, Union
 
 from google.protobuf import timestamp_pb2, wrappers_pb2
 
@@ -161,14 +161,13 @@ def new_complete_orchestration_action(
         id: int,
         status: pb.OrchestrationStatus,
         result: Union[str, None] = None,
-        failure_details: Union[pb.TaskFailureDetails, None] = None) -> pb.OrchestratorAction:
-
+        failure_details: Union[pb.TaskFailureDetails, None] = None,
+        carryover_events: Union[List[pb.HistoryEvent], None] = None) -> pb.OrchestratorAction:
     completeOrchestrationAction = pb.CompleteOrchestrationAction(
         orchestrationStatus=status,
         result=get_string_value(result),
-        failureDetails=failure_details)
-
-    # TODO: CarryoverEvents
+        failureDetails=failure_details,
+        carryoverEvents=carryover_events)
 
     return pb.OrchestratorAction(id=id, completeOrchestration=completeOrchestrationAction)
 

--- a/durabletask/internal/shared.py
+++ b/durabletask/internal/shared.py
@@ -26,9 +26,10 @@ def get_grpc_channel(host_address: Union[str, None]) -> grpc.Channel:
 
 
 def get_logger(
+        name_suffix: str,
         log_handler: Union[logging.Handler, None] = None,
         log_formatter: Union[logging.Formatter, None] = None) -> logging.Logger:
-    logger = logging.Logger("durabletask")
+    logger = logging.Logger(f"durabletask-{name_suffix}")
 
     # Add a default log handler if none is provided
     if log_handler is None:

--- a/durabletask/task.py
+++ b/durabletask/task.py
@@ -147,6 +147,19 @@ class OrchestrationContext(ABC):
         """
         pass
 
+    @abstractmethod
+    def continue_as_new(self, new_input: Any, *, save_events: bool = False) -> None:
+        """Continue the orchestration execution as a new instance.
+
+        Parameters
+        ----------
+        new_input : Any
+            The new input to use for the new orchestration instance.
+        save_events : bool
+            A flag indicating whether to add any unprocessed external events in the new orchestration history.
+        """
+        pass
+
 
 class FailureDetails:
     def __init__(self, message: str, error_type: str, stack_trace: Union[str, None]):

--- a/tests/test_activity_executor.py
+++ b/tests/test_activity_executor.py
@@ -2,12 +2,16 @@
 # Licensed under the MIT License.
 
 import json
+import logging
 from typing import Any, Tuple, Union
 
-import durabletask.internal.shared as shared
 from durabletask import task, worker
 
-TEST_LOGGER = shared.get_logger()
+logging.basicConfig(
+    format='%(asctime)s.%(msecs)03d %(name)s %(levelname)s: %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S',
+    level=logging.DEBUG)
+TEST_LOGGER = logging.getLogger("tests")
 TEST_INSTANCE_ID = 'abc123'
 TEST_TASK_ID = 42
 

--- a/tests/test_orchestration_e2e.py
+++ b/tests/test_orchestration_e2e.py
@@ -232,3 +232,39 @@ def test_terminate():
         assert state is not None
         assert state.runtime_status == client.OrchestrationStatus.TERMINATED
         assert state.serialized_output == json.dumps("some reason for termination")
+
+
+def test_continue_as_new():
+    all_results = []
+
+    def orchestrator(ctx: task.OrchestrationContext, input: int):
+        result = yield ctx.wait_for_external_event("my_event")
+        if not ctx.is_replaying:
+            # NOTE: Real orchestrations should never interact with nonlocal variables like this.
+            nonlocal all_results
+            all_results.append(result)
+
+        if len(all_results) <= 4:
+            ctx.continue_as_new(max(all_results), save_events=True)
+        else:
+            return all_results
+
+    # Start a worker, which will connect to the sidecar in a background thread
+    with worker.TaskHubGrpcWorker() as w:
+        w.add_orchestrator(orchestrator)
+        w.start()
+
+        task_hub_client = client.TaskHubGrpcClient()
+        id = task_hub_client.schedule_new_orchestration(orchestrator, input=0)
+        task_hub_client.raise_orchestration_event(id, "my_event", data=1)
+        task_hub_client.raise_orchestration_event(id, "my_event", data=2)
+        task_hub_client.raise_orchestration_event(id, "my_event", data=3)
+        task_hub_client.raise_orchestration_event(id, "my_event", data=4)
+        task_hub_client.raise_orchestration_event(id, "my_event", data=5)
+
+        state = task_hub_client.wait_for_orchestration_completion(id, timeout=30)
+        assert state is not None
+        assert state.runtime_status == client.OrchestrationStatus.COMPLETED
+        assert state.serialized_output == json.dumps(all_results)
+        assert state.serialized_input == json.dumps(4)
+        assert all_results == [1, 2, 3, 4, 5]


### PR DESCRIPTION
This PR adds support for the [continue-as-new](https://docs.dapr.io/developing-applications/building-blocks/workflow/workflow-features-concepts/#infinite-loops-and-eternal-workflows) API in orchestrations.

FYI @DeepanshuA we'll want to expose this in the Dapr Workflow SDK as well.