### PR TITLE
Remove Python 3.7 support due to EOL

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3
@@ -32,7 +32,6 @@ jobs:
     - name: Lint with flake8
       run: |
         flake8 . --count --show-source --statistics --exit-zero
-      if: matrix.python-version != '3.7'
     - name: Pytest unit tests
       run: |
         pytest -m "not e2e" --verbose

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Orchestrations can specify retry policies for activities and sub-orchestrations.
 
 ### Prerequisites
 
-- Python 3.7 or higher (Python 3.8 or higher is recommended when running tests or making contributions)
+- Python 3.8
 - A Durable Task-compatible sidecar, like [Dapr Workflow](https://docs.dapr.io/developing-applications/building-blocks/workflow/workflow-overview/)
 
 ### Installing the Durable Task Python client SDK

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "License :: OSI Approved :: MIT License",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {file = "LICENSE"}
 readme = "README.md"
 dependencies = [


### PR DESCRIPTION
Python 3.7 is now end of life and no longer receives security updates.

This removes Python 3.7 support and also removes it from CI runs.

(The next release of the Dapr SDK has also removed Python 3.7 support)