### PR TITLE
Add metadata option to intercept grpc channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,21 @@
-## v0.1.0
+## Unreleased
+
+### New
+
+- Add gRPC metadata option ([#16](https://github.com/microsoft/durabletask-python/pull/16)) - contributed by [@DeepanshuA](https://github.com/DeepanshuA)
+
+### Changes
+
+- Removed Python 3.7 support due to EOL ([#14](https://github.com/microsoft/durabletask-python/pull/14)) - contributed by [@berndverst](https://github.com/berndverst)
+
+## v0.1.0b
+
+### New
+
+- Continue-as-new ([#9](https://github.com/microsoft/durabletask-python/pull/9))
+- Support for Python 3.7+ ([#10](https://github.com/microsoft/durabletask-python/pull/10)) - contributed by [@DeepanshuA](https://github.com/DeepanshuA)
+
+## v0.1.0a
 
 Initial release, which includes the following features:
 

--- a/durabletask/client.py
+++ b/durabletask/client.py
@@ -6,7 +6,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, Optional, TypeVar, Union
+from typing import Any, List, Tuple, TypeVar, Union
 
 import grpc
 from google.protobuf import wrappers_pb2
@@ -93,7 +93,7 @@ class TaskHubGrpcClient:
 
     def __init__(self, *,
                  host_address: Union[str, None] = None,
-                 metadata: Optional[Dict[str, Any]],
+                 metadata: List[Tuple[str, str]],
                  log_handler=None,
                  log_formatter: Union[logging.Formatter, None] = None):
         channel = shared.get_grpc_channel(host_address, metadata)

--- a/durabletask/client.py
+++ b/durabletask/client.py
@@ -93,8 +93,8 @@ class TaskHubGrpcClient:
 
     def __init__(self, *,
                  host_address: Union[str, None] = None,
-                 metadata: List[Tuple[str, str]],
-                 log_handler=None,
+                 metadata: Union[List[Tuple[str, str]], None] = None,
+                 log_handler = None,
                  log_formatter: Union[logging.Formatter, None] = None):
         channel = shared.get_grpc_channel(host_address, metadata)
         self._stub = stubs.TaskHubSidecarServiceStub(channel)

--- a/durabletask/client.py
+++ b/durabletask/client.py
@@ -6,7 +6,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, TypeVar, Union
+from typing import Any, Dict, Optional, TypeVar, Union
 
 import grpc
 from google.protobuf import wrappers_pb2
@@ -93,9 +93,10 @@ class TaskHubGrpcClient:
 
     def __init__(self, *,
                  host_address: Union[str, None] = None,
+                 metadata: Optional[Dict[str, Any]],
                  log_handler=None,
                  log_formatter: Union[logging.Formatter, None] = None):
-        channel = shared.get_grpc_channel(host_address)
+        channel = shared.get_grpc_channel(host_address, metadata)
         self._stub = stubs.TaskHubSidecarServiceStub(channel)
         self._logger = shared.get_logger("client", log_handler, log_formatter)
 

--- a/durabletask/internal/grpc_interceptor.py
+++ b/durabletask/internal/grpc_interceptor.py
@@ -1,56 +1,91 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from typing import Any, Dict, Optional
+from collections import namedtuple
+from typing import List, Tuple
 
 import grpc
 
+
+class _ClientCallDetails(
+        namedtuple(
+            '_ClientCallDetails',
+            ['method', 'timeout', 'metadata', 'credentials', 'wait_for_ready', 'compression']),
+        grpc.ClientCallDetails):
+    """This is an implementation of the ClientCallDetails interface needed for interceptors.
+    This class takes six named values and inherits the ClientCallDetails from grpc package.
+    This class encloses the values that describe a RPC to be invoked.
+    """
+    pass
+
+def intercept_call(
+            client_call_details: _ClientCallDetails, metadata: List[Tuple[str, str]]) -> _ClientCallDetails:
+    new_metadata = []
+    new_client_call_details = client_call_details
+    if client_call_details.metadata is not None:
+        new_metadata = list(metadata)
+    if metadata is not None:
+        new_metadata.extend(metadata)
+        new_client_call_details = _ClientCallDetails(
+            client_call_details.method,
+            client_call_details.timeout,
+            metadata=new_metadata,
+            credentials=client_call_details.credentials,
+            wait_for_ready=client_call_details.wait_for_ready,
+            compression=client_call_details.compression,
+        )
+    return new_client_call_details
 
 class UnaryUnaryClientInterceptorImpl (grpc.UnaryUnaryClientInterceptor):
     """The class implements a UnaryUnaryClientInterceptor from grpc to add an interceptor to add
     additional headers to all calls as needed."""
 
-    def __init__(self, metadata: Optional[Dict[str, Any]]):
+    def __init__(self, metadata: List[Tuple[str, str]]):
         super().__init__()
         self._metadata = metadata
 
     def intercept_unary_unary(self, continuation, client_call_details, request):
-        if self._metadata:
-            client_call_details = client_call_details._replace(metadata=self._metadata)
-        return continuation(client_call_details, request)
+        new_client_call_details = intercept_call(client_call_details, self._metadata)
+        return continuation(new_client_call_details, request)
 
 class UnaryStreamClientInterceptorImpl (grpc.UnaryStreamClientInterceptor):
     """The class implements a UnaryStreamClientInterceptor from grpc to add an interceptor to add
     additional headers to all calls as needed."""
 
-    def __init__(self, metadata: Optional[Dict[str, Any]]):
+    def __init__(self, metadata: List[Tuple[str, str]]):
         super().__init__()
         self._metadata = metadata
 
     def intercept_unary_stream(self, continuation, client_call_details, request):
-        client_call_details = client_call_details._replace(metadata=self._metadata)
-        return continuation(client_call_details, request)
+        # client_call_details = client_call_details._replace(metadata=self._metadata)
+        # return continuation(client_call_details, request)
+        new_client_call_details = intercept_call(client_call_details, self._metadata)
+        return continuation(new_client_call_details, request)
 
 class StreamUnaryClientInterceptorImpl (grpc.StreamUnaryClientInterceptor):
     """The class implements a StreamUnaryClientInterceptor from grpc to add an interceptor to add
     additional headers to all calls as needed."""
 
-    def __init__(self, metadata: Optional[Dict[str, Any]]):
+    def __init__(self, metadata: List[Tuple[str, str]]):
         super().__init__()
         self._metadata = metadata
 
     def intercept_stream_unary(self, continuation, client_call_details, request):
-        client_call_details = client_call_details._replace(metadata=self._metadata)
-        return continuation(client_call_details, request)
+        # client_call_details = client_call_details._replace(metadata=self._metadata)
+        # return continuation(client_call_details, request)
+        new_client_call_details = intercept_call(client_call_details, self._metadata)
+        return continuation(new_client_call_details, request)
     
 class StreamStreamClientInterceptorImpl (grpc.StreamStreamClientInterceptor):
     """The class implements a StreamStreamClientInterceptor from grpc to add an interceptor to add
     additional headers to all calls as needed."""
 
-    def __init__(self, metadata: Optional[Dict[str, Any]]):
+    def __init__(self, metadata: List[Tuple[str, str]]):
         super().__init__()
         self._metadata = metadata
 
     def intercept_stream_stream(self, continuation, client_call_details, request):
-        client_call_details = client_call_details._replace(metadata=self._metadata)
-        return continuation(client_call_details, request)
+        # client_call_details = client_call_details._replace(metadata=self._metadata)
+        # return continuation(client_call_details, request)
+        new_client_call_details = intercept_call(client_call_details, self._metadata)
+        return continuation(new_client_call_details, request)

--- a/durabletask/internal/grpc_interceptor.py
+++ b/durabletask/internal/grpc_interceptor.py
@@ -1,0 +1,56 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from typing import Any, Dict, Optional
+
+import grpc
+
+
+class UnaryUnaryClientInterceptorImpl (grpc.UnaryUnaryClientInterceptor):
+    """The class implements a UnaryUnaryClientInterceptor from grpc to add an interceptor to add
+    additional headers to all calls as needed."""
+
+    def __init__(self, metadata: Optional[Dict[str, Any]]):
+        super().__init__()
+        self._metadata = metadata
+
+    def intercept_unary_unary(self, continuation, client_call_details, request):
+        if self._metadata:
+            client_call_details = client_call_details._replace(metadata=self._metadata)
+        return continuation(client_call_details, request)
+
+class UnaryStreamClientInterceptorImpl (grpc.UnaryStreamClientInterceptor):
+    """The class implements a UnaryStreamClientInterceptor from grpc to add an interceptor to add
+    additional headers to all calls as needed."""
+
+    def __init__(self, metadata: Optional[Dict[str, Any]]):
+        super().__init__()
+        self._metadata = metadata
+
+    def intercept_unary_stream(self, continuation, client_call_details, request):
+        client_call_details = client_call_details._replace(metadata=self._metadata)
+        return continuation(client_call_details, request)
+
+class StreamUnaryClientInterceptorImpl (grpc.StreamUnaryClientInterceptor):
+    """The class implements a StreamUnaryClientInterceptor from grpc to add an interceptor to add
+    additional headers to all calls as needed."""
+
+    def __init__(self, metadata: Optional[Dict[str, Any]]):
+        super().__init__()
+        self._metadata = metadata
+
+    def intercept_stream_unary(self, continuation, client_call_details, request):
+        client_call_details = client_call_details._replace(metadata=self._metadata)
+        return continuation(client_call_details, request)
+    
+class StreamStreamClientInterceptorImpl (grpc.StreamStreamClientInterceptor):
+    """The class implements a StreamStreamClientInterceptor from grpc to add an interceptor to add
+    additional headers to all calls as needed."""
+
+    def __init__(self, metadata: Optional[Dict[str, Any]]):
+        super().__init__()
+        self._metadata = metadata
+
+    def intercept_stream_stream(self, continuation, client_call_details, request):
+        client_call_details = client_call_details._replace(metadata=self._metadata)
+        return continuation(client_call_details, request)

--- a/durabletask/internal/grpc_interceptor.py
+++ b/durabletask/internal/grpc_interceptor.py
@@ -34,15 +34,18 @@ class DefaultClientInterceptorImpl (
                 self, client_call_details: _ClientCallDetails) -> grpc.ClientCallDetails:
         """Internal intercept_call implementation which adds metadata to grpc metadata in the RPC
             call details."""
+        if self._metadata is None:
+            return client_call_details
+        
         if client_call_details.metadata is not None:
             metadata = list(client_call_details.metadata)
         else:
             metadata = []
-        if self._metadata is not None:
-            metadata.extend(self._metadata)
-            client_call_details = _ClientCallDetails(
-                client_call_details.method, client_call_details.timeout, metadata,
-                client_call_details.credentials, client_call_details.wait_for_ready, client_call_details.compression)
+        
+        metadata.extend(self._metadata)
+        client_call_details = _ClientCallDetails(
+            client_call_details.method, client_call_details.timeout, metadata,
+            client_call_details.credentials, client_call_details.wait_for_ready, client_call_details.compression)
 
         return client_call_details
 

--- a/durabletask/internal/grpc_interceptor.py
+++ b/durabletask/internal/grpc_interceptor.py
@@ -34,13 +34,15 @@ class DefaultClientInterceptorImpl (
                 self, client_call_details: _ClientCallDetails) -> grpc.ClientCallDetails:
         """Internal intercept_call implementation which adds metadata to grpc metadata in the RPC
             call details."""
-        metadata = []
         if client_call_details.metadata is not None:
             metadata = list(client_call_details.metadata)
-        metadata.extend(self._metadata)
-        client_call_details = _ClientCallDetails(
-            client_call_details.method, client_call_details.timeout, metadata,
-            client_call_details.credentials, client_call_details.wait_for_ready, client_call_details.compression)
+        else:
+            metadata = []
+        if self._metadata is not None:
+            metadata.extend(self._metadata)
+            client_call_details = _ClientCallDetails(
+                client_call_details.method, client_call_details.timeout, metadata,
+                client_call_details.credentials, client_call_details.wait_for_ready, client_call_details.compression)
 
         return client_call_details
 

--- a/durabletask/internal/grpc_interceptor.py
+++ b/durabletask/internal/grpc_interceptor.py
@@ -18,76 +18,44 @@ class _ClientCallDetails(
     """
     pass
 
-def _intercept_call(
-            client_call_details: _ClientCallDetails, metadata: List[Tuple[str, str]]) -> _ClientCallDetails:
-    """Internal intercept_call implementation which adds metadata to grpc metadata in the RPC
-        call details."""
-    new_metadata = []
-    new_client_call_details = client_call_details
-    if client_call_details.metadata is not None:
-        new_metadata = list(metadata)
-    if metadata is not None:
-        new_metadata.extend(metadata)
-        new_client_call_details = _ClientCallDetails(
-            client_call_details.method,
-            client_call_details.timeout,
-            metadata=new_metadata,
-            credentials=client_call_details.credentials,
-            wait_for_ready=client_call_details.wait_for_ready,
-            compression=client_call_details.compression,
-        )
-    return new_client_call_details
 
-class UnaryUnaryClientInterceptorImpl (grpc.UnaryUnaryClientInterceptor):
-    """The class implements a UnaryUnaryClientInterceptor from grpc to add an interceptor to add
-    additional headers to all calls as needed."""
+class DefaultClientInterceptorImpl (
+    grpc.UnaryUnaryClientInterceptor, grpc.UnaryStreamClientInterceptor,
+    grpc.StreamUnaryClientInterceptor, grpc.StreamStreamClientInterceptor):
+    """The class implements a UnaryUnaryClientInterceptor, UnaryStreamClientInterceptor,
+    StreamUnaryClientInterceptor and StreamStreamClientInterceptor from grpc to add an 
+    interceptor to add additional headers to all calls as needed."""
 
     def __init__(self, metadata: List[Tuple[str, str]]):
         super().__init__()
         self._metadata = metadata
+
+    def _intercept_call(
+                self, client_call_details: _ClientCallDetails) -> grpc.ClientCallDetails:
+        """Internal intercept_call implementation which adds metadata to grpc metadata in the RPC
+            call details."""
+        metadata = []
+        if client_call_details.metadata is not None:
+            metadata = list(client_call_details.metadata)
+        metadata.extend(self._metadata)
+        client_call_details = _ClientCallDetails(
+            client_call_details.method, client_call_details.timeout, metadata,
+            client_call_details.credentials, client_call_details.wait_for_ready, client_call_details.compression)
+
+        return client_call_details
 
     def intercept_unary_unary(self, continuation, client_call_details, request):
-        new_client_call_details = _intercept_call(client_call_details, self._metadata)
+        new_client_call_details = self._intercept_call(client_call_details)
         return continuation(new_client_call_details, request)
-
-class UnaryStreamClientInterceptorImpl (grpc.UnaryStreamClientInterceptor):
-    """The class implements a UnaryStreamClientInterceptor from grpc to add an interceptor to add
-    additional headers to all calls as needed."""
-
-    def __init__(self, metadata: List[Tuple[str, str]]):
-        super().__init__()
-        self._metadata = metadata
 
     def intercept_unary_stream(self, continuation, client_call_details, request):
-        # client_call_details = client_call_details._replace(metadata=self._metadata)
-        # return continuation(client_call_details, request)
-        new_client_call_details = _intercept_call(client_call_details, self._metadata)
+        new_client_call_details = self._intercept_call(client_call_details)
         return continuation(new_client_call_details, request)
-
-class StreamUnaryClientInterceptorImpl (grpc.StreamUnaryClientInterceptor):
-    """The class implements a StreamUnaryClientInterceptor from grpc to add an interceptor to add
-    additional headers to all calls as needed."""
-
-    def __init__(self, metadata: List[Tuple[str, str]]):
-        super().__init__()
-        self._metadata = metadata
 
     def intercept_stream_unary(self, continuation, client_call_details, request):
-        # client_call_details = client_call_details._replace(metadata=self._metadata)
-        # return continuation(client_call_details, request)
-        new_client_call_details = _intercept_call(client_call_details, self._metadata)
+        new_client_call_details = self._intercept_call(client_call_details)
         return continuation(new_client_call_details, request)
-    
-class StreamStreamClientInterceptorImpl (grpc.StreamStreamClientInterceptor):
-    """The class implements a StreamStreamClientInterceptor from grpc to add an interceptor to add
-    additional headers to all calls as needed."""
-
-    def __init__(self, metadata: List[Tuple[str, str]]):
-        super().__init__()
-        self._metadata = metadata
 
     def intercept_stream_stream(self, continuation, client_call_details, request):
-        # client_call_details = client_call_details._replace(metadata=self._metadata)
-        # return continuation(client_call_details, request)
-        new_client_call_details = _intercept_call(client_call_details, self._metadata)
+        new_client_call_details = self._intercept_call(client_call_details)
         return continuation(new_client_call_details, request)

--- a/durabletask/internal/grpc_interceptor.py
+++ b/durabletask/internal/grpc_interceptor.py
@@ -18,8 +18,10 @@ class _ClientCallDetails(
     """
     pass
 
-def intercept_call(
+def _intercept_call(
             client_call_details: _ClientCallDetails, metadata: List[Tuple[str, str]]) -> _ClientCallDetails:
+    """Internal intercept_call implementation which adds metadata to grpc metadata in the RPC
+        call details."""
     new_metadata = []
     new_client_call_details = client_call_details
     if client_call_details.metadata is not None:
@@ -45,7 +47,7 @@ class UnaryUnaryClientInterceptorImpl (grpc.UnaryUnaryClientInterceptor):
         self._metadata = metadata
 
     def intercept_unary_unary(self, continuation, client_call_details, request):
-        new_client_call_details = intercept_call(client_call_details, self._metadata)
+        new_client_call_details = _intercept_call(client_call_details, self._metadata)
         return continuation(new_client_call_details, request)
 
 class UnaryStreamClientInterceptorImpl (grpc.UnaryStreamClientInterceptor):
@@ -59,7 +61,7 @@ class UnaryStreamClientInterceptorImpl (grpc.UnaryStreamClientInterceptor):
     def intercept_unary_stream(self, continuation, client_call_details, request):
         # client_call_details = client_call_details._replace(metadata=self._metadata)
         # return continuation(client_call_details, request)
-        new_client_call_details = intercept_call(client_call_details, self._metadata)
+        new_client_call_details = _intercept_call(client_call_details, self._metadata)
         return continuation(new_client_call_details, request)
 
 class StreamUnaryClientInterceptorImpl (grpc.StreamUnaryClientInterceptor):
@@ -73,7 +75,7 @@ class StreamUnaryClientInterceptorImpl (grpc.StreamUnaryClientInterceptor):
     def intercept_stream_unary(self, continuation, client_call_details, request):
         # client_call_details = client_call_details._replace(metadata=self._metadata)
         # return continuation(client_call_details, request)
-        new_client_call_details = intercept_call(client_call_details, self._metadata)
+        new_client_call_details = _intercept_call(client_call_details, self._metadata)
         return continuation(new_client_call_details, request)
     
 class StreamStreamClientInterceptorImpl (grpc.StreamStreamClientInterceptor):
@@ -87,5 +89,5 @@ class StreamStreamClientInterceptorImpl (grpc.StreamStreamClientInterceptor):
     def intercept_stream_stream(self, continuation, client_call_details, request):
         # client_call_details = client_call_details._replace(metadata=self._metadata)
         # return continuation(client_call_details, request)
-        new_client_call_details = intercept_call(client_call_details, self._metadata)
+        new_client_call_details = _intercept_call(client_call_details, self._metadata)
         return continuation(new_client_call_details, request)

--- a/durabletask/internal/shared.py
+++ b/durabletask/internal/shared.py
@@ -20,11 +20,11 @@ def get_default_host_address() -> str:
     return "localhost:4001"
 
 
-def get_grpc_channel(host_address: Union[str, None], metadata: List[Tuple[str, str]]) -> grpc.Channel:
+def get_grpc_channel(host_address: Union[str, None], metadata: Union[List[Tuple[str, str]], None]) -> grpc.Channel:
     if host_address is None:
         host_address = get_default_host_address()
     channel = grpc.insecure_channel(host_address)
-    if metadata != None and len(metadata) > 0:
+    if metadata is not None and len(metadata) > 0:
         interceptors = [DefaultClientInterceptorImpl(metadata)]
         channel = grpc.intercept_channel(channel, *interceptors)
     return channel

--- a/durabletask/internal/shared.py
+++ b/durabletask/internal/shared.py
@@ -4,7 +4,6 @@
 import dataclasses
 import json
 import logging
-import os
 from types import SimpleNamespace
 from typing import Any, Dict, Optional, Union
 

--- a/durabletask/internal/shared.py
+++ b/durabletask/internal/shared.py
@@ -5,7 +5,7 @@ import dataclasses
 import json
 import logging
 from types import SimpleNamespace
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import grpc
 
@@ -22,7 +22,7 @@ def get_default_host_address() -> str:
     return "localhost:4001"
 
 
-def get_grpc_channel(host_address: Union[str, None], metadata: Optional[Dict[str, Any]]) -> grpc.Channel:
+def get_grpc_channel(host_address: Union[str, None], metadata: List[Tuple[str, str]]) -> grpc.Channel:
     if host_address is None:
         host_address = get_default_host_address()
     channel = grpc.insecure_channel(host_address)

--- a/durabletask/internal/shared.py
+++ b/durabletask/internal/shared.py
@@ -9,9 +9,7 @@ from typing import Any, Dict, List, Tuple, Union
 
 import grpc
 
-from durabletask.internal.grpc_interceptor import (
-    StreamStreamClientInterceptorImpl, StreamUnaryClientInterceptorImpl,
-    UnaryStreamClientInterceptorImpl, UnaryUnaryClientInterceptorImpl)
+from durabletask.internal.grpc_interceptor import DefaultClientInterceptorImpl
 
 # Field name used to indicate that an object was automatically serialized
 # and should be deserialized as a SimpleNamespace
@@ -27,11 +25,7 @@ def get_grpc_channel(host_address: Union[str, None], metadata: List[Tuple[str, s
         host_address = get_default_host_address()
     channel = grpc.insecure_channel(host_address)
     if metadata != None and len(metadata) > 0:
-        interceptors = [
-            UnaryUnaryClientInterceptorImpl(metadata), 
-            UnaryStreamClientInterceptorImpl(metadata), 
-            StreamUnaryClientInterceptorImpl(metadata), 
-            StreamStreamClientInterceptorImpl(metadata)]
+        interceptors = [DefaultClientInterceptorImpl(metadata)]
         channel = grpc.intercept_channel(channel, *interceptors)
     return channel
 

--- a/durabletask/worker.py
+++ b/durabletask/worker.py
@@ -6,8 +6,7 @@ import logging
 from datetime import datetime, timedelta
 from threading import Event, Thread
 from types import GeneratorType
-from typing import (Any, Dict, Generator, List, Optional, Sequence, TypeVar,
-                    Union)
+from typing import Any, Dict, Generator, List, Sequence, Tuple, TypeVar, Union
 
 import grpc
 from google.protobuf import empty_pb2
@@ -86,7 +85,7 @@ class TaskHubGrpcWorker:
 
     def __init__(self, *,
                  host_address: Union[str, None] = None,
-                 metadata: Optional[Dict[str, Any]],
+                 metadata: List[Tuple[str, str]],
                  log_handler=None,
                  log_formatter: Union[logging.Formatter, None] = None):
         self._registry = _Registry()

--- a/durabletask/worker.py
+++ b/durabletask/worker.py
@@ -85,8 +85,8 @@ class TaskHubGrpcWorker:
 
     def __init__(self, *,
                  host_address: Union[str, None] = None,
-                 metadata: List[Tuple[str, str]],
-                 log_handler=None,
+                 metadata: Union[List[Tuple[str, str]], None] = None,
+                 log_handler = None,
                  log_formatter: Union[logging.Formatter, None] = None):
         self._registry = _Registry()
         self._host_address = host_address if host_address else shared.get_default_host_address()


### PR DESCRIPTION
This PR adds option to pass a metadata to be used to intercept grpc channel.
This can be used to pass API Token kind of information.