### PR TITLE
Update version to 0.2b1, require Python 3.9+, and enhance GitHub Actions workflow

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -16,12 +16,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -35,3 +35,16 @@ jobs:
     - name: Pytest unit tests
       run: |
         pytest -m "not e2e" --verbose
+
+    # Sidecar for running e2e tests requires Go SDK
+    - name: Install Go SDK
+      uses: actions/setup-go@v5
+      with:
+        go-version: 'stable'
+
+    # Install and run the durabletask-go sidecar for running e2e tests
+    - name: Pytest e2e tests
+      run: |
+        go install github.com/microsoft/durabletask-go@main
+        durabletask-go --port 4001 &
+        pytest -m "e2e" --verbose

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
         "editor.defaultFormatter": "ms-python.autopep8",
         "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
-            "source.organizeImports": true,
+            "source.organizeImports": "explicit"
         },
         "editor.rulers": [
             119
@@ -29,5 +29,6 @@
         "coverage.xml",
         "jacoco.xml",
         "coverage.cobertura.xml"
-    ]
+    ],
+    "makefile.configureOnOpen": false
 }

--- a/durabletask/internal/grpc_interceptor.py
+++ b/durabletask/internal/grpc_interceptor.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 
 from collections import namedtuple
-from typing import List, Tuple
 
 import grpc
 
@@ -26,7 +25,7 @@ class DefaultClientInterceptorImpl (
     StreamUnaryClientInterceptor and StreamStreamClientInterceptor from grpc to add an 
     interceptor to add additional headers to all calls as needed."""
 
-    def __init__(self, metadata: List[Tuple[str, str]]):
+    def __init__(self, metadata: list[tuple[str, str]]):
         super().__init__()
         self._metadata = metadata
 

--- a/durabletask/internal/helpers.py
+++ b/durabletask/internal/helpers.py
@@ -3,7 +3,7 @@
 
 import traceback
 from datetime import datetime
-from typing import List, Union
+from typing import Optional
 
 from google.protobuf import timestamp_pb2, wrappers_pb2
 
@@ -12,14 +12,14 @@ import durabletask.internal.orchestrator_service_pb2 as pb
 # TODO: The new_xxx_event methods are only used by test code and should be moved elsewhere
 
 
-def new_orchestrator_started_event(timestamp: Union[datetime, None] = None) -> pb.HistoryEvent:
+def new_orchestrator_started_event(timestamp: Optional[datetime] = None) -> pb.HistoryEvent:
     ts = timestamp_pb2.Timestamp()
     if timestamp is not None:
         ts.FromDatetime(timestamp)
     return pb.HistoryEvent(eventId=-1, timestamp=ts, orchestratorStarted=pb.OrchestratorStartedEvent())
 
 
-def new_execution_started_event(name: str, instance_id: str, encoded_input: Union[str, None] = None) -> pb.HistoryEvent:
+def new_execution_started_event(name: str, instance_id: str, encoded_input: Optional[str] = None) -> pb.HistoryEvent:
     return pb.HistoryEvent(
         eventId=-1,
         timestamp=timestamp_pb2.Timestamp(),
@@ -49,7 +49,7 @@ def new_timer_fired_event(timer_id: int, fire_at: datetime) -> pb.HistoryEvent:
     )
 
 
-def new_task_scheduled_event(event_id: int, name: str, encoded_input: Union[str, None] = None) -> pb.HistoryEvent:
+def new_task_scheduled_event(event_id: int, name: str, encoded_input: Optional[str] = None) -> pb.HistoryEvent:
     return pb.HistoryEvent(
         eventId=event_id,
         timestamp=timestamp_pb2.Timestamp(),
@@ -57,7 +57,7 @@ def new_task_scheduled_event(event_id: int, name: str, encoded_input: Union[str,
     )
 
 
-def new_task_completed_event(event_id: int, encoded_output: Union[str, None] = None) -> pb.HistoryEvent:
+def new_task_completed_event(event_id: int, encoded_output: Optional[str] = None) -> pb.HistoryEvent:
     return pb.HistoryEvent(
         eventId=-1,
         timestamp=timestamp_pb2.Timestamp(),
@@ -77,7 +77,7 @@ def new_sub_orchestration_created_event(
         event_id: int,
         name: str,
         instance_id: str,
-        encoded_input: Union[str, None] = None) -> pb.HistoryEvent:
+        encoded_input: Optional[str] = None) -> pb.HistoryEvent:
     return pb.HistoryEvent(
         eventId=event_id,
         timestamp=timestamp_pb2.Timestamp(),
@@ -88,7 +88,7 @@ def new_sub_orchestration_created_event(
     )
 
 
-def new_sub_orchestration_completed_event(event_id: int, encoded_output: Union[str, None] = None) -> pb.HistoryEvent:
+def new_sub_orchestration_completed_event(event_id: int, encoded_output: Optional[str] = None) -> pb.HistoryEvent:
     return pb.HistoryEvent(
         eventId=-1,
         timestamp=timestamp_pb2.Timestamp(),
@@ -116,7 +116,7 @@ def new_failure_details(ex: Exception) -> pb.TaskFailureDetails:
     )
 
 
-def new_event_raised_event(name: str, encoded_input: Union[str, None] = None) -> pb.HistoryEvent:
+def new_event_raised_event(name: str, encoded_input: Optional[str] = None) -> pb.HistoryEvent:
     return pb.HistoryEvent(
         eventId=-1,
         timestamp=timestamp_pb2.Timestamp(),
@@ -140,7 +140,7 @@ def new_resume_event() -> pb.HistoryEvent:
     )
 
 
-def new_terminated_event(*, encoded_output: Union[str, None] = None) -> pb.HistoryEvent:
+def new_terminated_event(*, encoded_output: Optional[str] = None) -> pb.HistoryEvent:
     return pb.HistoryEvent(
         eventId=-1,
         timestamp=timestamp_pb2.Timestamp(),
@@ -150,7 +150,7 @@ def new_terminated_event(*, encoded_output: Union[str, None] = None) -> pb.Histo
     )
 
 
-def get_string_value(val: Union[str, None]) -> Union[wrappers_pb2.StringValue, None]:
+def get_string_value(val: Optional[str]) -> Optional[wrappers_pb2.StringValue]:
     if val is None:
         return None
     else:
@@ -160,9 +160,9 @@ def get_string_value(val: Union[str, None]) -> Union[wrappers_pb2.StringValue, N
 def new_complete_orchestration_action(
         id: int,
         status: pb.OrchestrationStatus,
-        result: Union[str, None] = None,
-        failure_details: Union[pb.TaskFailureDetails, None] = None,
-        carryover_events: Union[List[pb.HistoryEvent], None] = None) -> pb.OrchestratorAction:
+        result: Optional[str] = None,
+        failure_details: Optional[pb.TaskFailureDetails] = None,
+        carryover_events: Optional[list[pb.HistoryEvent]] = None) -> pb.OrchestratorAction:
     completeOrchestrationAction = pb.CompleteOrchestrationAction(
         orchestrationStatus=status,
         result=get_string_value(result),
@@ -178,7 +178,7 @@ def new_create_timer_action(id: int, fire_at: datetime) -> pb.OrchestratorAction
     return pb.OrchestratorAction(id=id, createTimer=pb.CreateTimerAction(fireAt=timestamp))
 
 
-def new_schedule_task_action(id: int, name: str, encoded_input: Union[str, None]) -> pb.OrchestratorAction:
+def new_schedule_task_action(id: int, name: str, encoded_input: Optional[str]) -> pb.OrchestratorAction:
     return pb.OrchestratorAction(id=id, scheduleTask=pb.ScheduleTaskAction(
         name=name,
         input=get_string_value(encoded_input)
@@ -194,8 +194,8 @@ def new_timestamp(dt: datetime) -> timestamp_pb2.Timestamp:
 def new_create_sub_orchestration_action(
         id: int,
         name: str,
-        instance_id: Union[str, None],
-        encoded_input: Union[str, None]) -> pb.OrchestratorAction:
+        instance_id: Optional[str],
+        encoded_input: Optional[str]) -> pb.OrchestratorAction:
     return pb.OrchestratorAction(id=id, createSubOrchestration=pb.CreateSubOrchestrationAction(
         name=name,
         instanceId=instance_id,

--- a/examples/fanout_fanin.py
+++ b/examples/fanout_fanin.py
@@ -3,12 +3,11 @@ that a dynamic number activity functions in parallel, waits for them all
 to complete, and prints an aggregate summary of the outputs."""
 import random
 import time
-from typing import List
 
 from durabletask import client, task, worker
 
 
-def get_work_items(ctx: task.ActivityContext, _) -> List[str]:
+def get_work_items(ctx: task.ActivityContext, _) -> list[str]:
     """Activity function that returns a list of work items"""
     # return a random number of work items
     count = random.randint(2, 10)
@@ -32,11 +31,11 @@ def orchestrator(ctx: task.OrchestrationContext, _):
     activity functions in parallel, waits for them all to complete, and prints
     an aggregate summary of the outputs"""
 
-    work_items: List[str] = yield ctx.call_activity(get_work_items)
+    work_items: list[str] = yield ctx.call_activity(get_work_items)
 
     # execute the work-items in parallel and wait for them all to return
     tasks = [ctx.call_activity(process_work_item, input=item) for item in work_items]
-    results: List[int] = yield task.when_all(tasks)
+    results: list[int] = yield task.when_all(tasks)
 
     # return an aggregate summary of the results
     return {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "durabletask"
-version = "0.1.1-alpha.1"
+version = "0.2b1"
 description = "A Durable Task Client SDK for Python"
 keywords = [
     "durable",
@@ -21,7 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "License :: OSI Approved :: MIT License",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 readme = "README.md"
 dependencies = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 autopep8
 grpcio
 grpcio-tools
+protobuf
 pytest
 pytest-cov

--- a/tests/test_activity_executor.py
+++ b/tests/test_activity_executor.py
@@ -3,7 +3,7 @@
 
 import json
 import logging
-from typing import Any, Tuple, Union
+from typing import Any, Optional, Tuple
 
 from durabletask import task, worker
 
@@ -40,7 +40,7 @@ def test_activity_not_registered():
 
     executor, _ = _get_activity_executor(test_activity)
 
-    caught_exception: Union[Exception, None] = None
+    caught_exception: Optional[Exception] = None
     try:
         executor.execute(TEST_INSTANCE_ID, "Bogus", TEST_TASK_ID, None)
     except Exception as ex:

--- a/tests/test_orchestration_e2e.py
+++ b/tests/test_orchestration_e2e.py
@@ -466,4 +466,4 @@ def test_custom_status():
     assert state.runtime_status == client.OrchestrationStatus.COMPLETED
     assert state.serialized_input is None
     assert state.serialized_output is None
-    assert state.serialized_custom_status is "\"foobaz\""
+    assert state.serialized_custom_status == "\"foobaz\""

--- a/tests/test_orchestration_executor.py
+++ b/tests/test_orchestration_executor.py
@@ -4,7 +4,6 @@
 import json
 import logging
 from datetime import datetime, timedelta
-from typing import List
 
 import pytest
 
@@ -1184,7 +1183,7 @@ def test_when_all_with_retry():
     assert str(ex) in complete_action.failureDetails.errorMessage
 
 
-def get_and_validate_single_complete_orchestration_action(actions: List[pb.OrchestratorAction]) -> pb.CompleteOrchestrationAction:
+def get_and_validate_single_complete_orchestration_action(actions: list[pb.OrchestratorAction]) -> pb.CompleteOrchestrationAction:
     assert len(actions) == 1
     assert type(actions[0]) is pb.OrchestratorAction
     assert actions[0].HasField("completeOrchestration")


### PR DESCRIPTION
- Bump version in `pyproject.toml` to 0.2b1 and update Python requirement to >=3.9.
- Add `protobuf` dependency in `requirements.txt`.
- Update GitHub Actions workflow to support Python versions 3.9 to 3.13 and upgrade action versions.
- Refactor type hints in various files to use `Optional` and `list` instead of `Union` and `List`.
- Improve handling of custom status in orchestration context and related functions.
- Fix purge implementation to pass required parameters.