### PR TITLE
Remove protocol prefix from host name and auto-configure secure mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
-- Protos are compiled with gRPC 1.62.3 / protobuf 3.25.X instead of the latest release. This ensures compatibility with a wider range of grpcio versions for better compatibility with other packages / libraries.
+- Protos are compiled with gRPC 1.62.3 / protobuf 3.25.X instead of the latest release. This ensures compatibility with a wider range of grpcio versions for better compatibility with other packages / libraries ([#36](https://github.com/microsoft/durabletask-python/pull/36)) - by [@berndverst](https://github.com/berndverst)
+- Http and grpc protocols and their secure variants are stripped from the host name parameter if provided. Secure mode is enabled if the protocol provided is https or grpcs ([#38](https://github.com/microsoft/durabletask-python/pull/38) - by [@berndverst)(https://github.com/berndverst)
 
 ### Updates
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Orchestrations can specify retry policies for activities and sub-orchestrations.
 
 ### Prerequisites
 
-- Python 3.8
+- Python 3.9
 - A Durable Task-compatible sidecar, like [Dapr Workflow](https://docs.dapr.io/developing-applications/building-blocks/workflow/workflow-overview/)
 
 ### Installing the Durable Task Python client SDK

--- a/durabletask/internal/shared.py
+++ b/durabletask/internal/shared.py
@@ -15,6 +15,9 @@ from durabletask.internal.grpc_interceptor import DefaultClientInterceptorImpl
 # and should be deserialized as a SimpleNamespace
 AUTO_SERIALIZED = "__durabletask_autoobject__"
 
+SECURE_PROTOCOLS = ["https://", "grpcs://"]
+INSECURE_PROTOCOLS = ["http://", "grpc://"]
+
 
 def get_default_host_address() -> str:
     return "localhost:4001"
@@ -26,6 +29,20 @@ def get_grpc_channel(
         secure_channel: bool = False) -> grpc.Channel:
     if host_address is None:
         host_address = get_default_host_address()
+
+    for protocol in SECURE_PROTOCOLS:
+        if host_address.lower().startswith(protocol):
+            secure_channel = True
+            # remove the protocol from the host name
+            host_address = host_address[len(protocol):]
+            break
+
+    for protocol in INSECURE_PROTOCOLS:
+        if host_address.lower().startswith(protocol):
+            secure_channel = False
+            # remove the protocol from the host name
+            host_address = host_address[len(protocol):]
+            break
 
     if secure_channel:
         channel = grpc.secure_channel(host_address, grpc.ssl_channel_credentials())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, Mock, ANY
+from unittest.mock import patch, ANY
 
 from durabletask.internal.shared import (DefaultClientInterceptorImpl,
                                          get_default_host_address,


### PR DESCRIPTION
Remove protocol prefixes from host name and auto-configure secure mode

This addresses an issue where connections fail if the provided host name starts with a `http://` or `https://` prefix.

When `https` and `grpcs` were provided as prefixes, we force secure mode to be enabled.