### PR TITLE
Add orchestration versioning support

### DIFF
--- a/.github/workflows/durabletask-azuremanaged.yml
+++ b/.github/workflows/durabletask-azuremanaged.yml
@@ -72,6 +72,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Install durabletask-azuremanaged locally
+        working-directory: durabletask-azuremanaged
+        run: |
+          pip install . --no-deps --force-reinstall
+
       - name: Run the tests
         working-directory: tests/durabletask-azuremanaged
         run: |

--- a/.github/workflows/durabletask-azuremanaged.yml
+++ b/.github/workflows/durabletask-azuremanaged.yml
@@ -77,6 +77,10 @@ jobs:
         run: |
           pip install . --no-deps --force-reinstall
 
+      - name: Install durabletask locally
+        run: |
+          pip install . --no-deps --force-reinstall
+
       - name: Run the tests
         working-directory: tests/durabletask-azuremanaged
         run: |

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,10 @@
     ],
     "python.analysis.typeCheckingMode": "basic",
     "python.testing.pytestArgs": [
-        "tests"
+        "-v",
+        "--cov=durabletask/",
+        "--cov-report=lcov",
+        "tests/"
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,10 +14,7 @@
     ],
     "python.analysis.typeCheckingMode": "basic",
     "python.testing.pytestArgs": [
-        "-v",
-        "--cov=durabletask/",
-        "--cov-report=lcov",
-        "tests/"
+        "tests"
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
@@ -30,5 +27,6 @@
         "jacoco.xml",
         "coverage.cobertura.xml"
     ],
-    "makefile.configureOnOpen": false
+    "makefile.configureOnOpen": false,
+    "debugpy.debugJustMyCode": false
 }

--- a/durabletask-azuremanaged/durabletask/azuremanaged/client.py
+++ b/durabletask-azuremanaged/durabletask/azuremanaged/client.py
@@ -17,7 +17,8 @@ class DurableTaskSchedulerClient(TaskHubGrpcClient):
                  host_address: str,
                  taskhub: str,
                  token_credential: Optional[TokenCredential],
-                 secure_channel: bool = True):
+                 secure_channel: bool = True,
+                 default_version: Optional[str] = None):
 
         if not taskhub:
             raise ValueError("Taskhub value cannot be empty. Please provide a value for your taskhub")
@@ -30,4 +31,5 @@ class DurableTaskSchedulerClient(TaskHubGrpcClient):
             host_address=host_address,
             secure_channel=secure_channel,
             metadata=None,
-            interceptors=interceptors)
+            interceptors=interceptors,
+            default_version=default_version)

--- a/durabletask/__init__.py
+++ b/durabletask/__init__.py
@@ -3,8 +3,8 @@
 
 """Durable Task SDK for Python"""
 
-from durabletask.worker import ConcurrencyOptions
+from durabletask.worker import ConcurrencyOptions, VersioningOptions
 
-__all__ = ["ConcurrencyOptions"]
+__all__ = ["ConcurrencyOptions", "VersioningOptions"]
 
 PACKAGE_NAME = "durabletask"

--- a/durabletask/internal/exceptions.py
+++ b/durabletask/internal/exceptions.py
@@ -1,3 +1,7 @@
+class VersionFailureException(Exception):
+    pass
+
+
 class AbandonOrchestrationError(Exception):
     def __init__(self, *args: object) -> None:
         super().__init__(*args)

--- a/durabletask/internal/exceptions.py
+++ b/durabletask/internal/exceptions.py
@@ -1,0 +1,3 @@
+class AbandonOrchestrationError(Exception):
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)

--- a/durabletask/internal/helpers.py
+++ b/durabletask/internal/helpers.py
@@ -199,11 +199,13 @@ def new_create_sub_orchestration_action(
         id: int,
         name: str,
         instance_id: Optional[str],
-        encoded_input: Optional[str]) -> pb.OrchestratorAction:
+        encoded_input: Optional[str],
+        version: Optional[str]) -> pb.OrchestratorAction:
     return pb.OrchestratorAction(id=id, createSubOrchestration=pb.CreateSubOrchestrationAction(
         name=name,
         instanceId=instance_id,
-        input=get_string_value(encoded_input)
+        input=get_string_value(encoded_input),
+        version=get_string_value(version)
     ))
 
 

--- a/durabletask/task.py
+++ b/durabletask/task.py
@@ -37,6 +37,21 @@ class OrchestrationContext(ABC):
 
     @property
     @abstractmethod
+    def version(self) -> Optional[str]:
+        """Get the version of the orchestration instance.
+
+        This version is set when the orchestration is scheduled and can be used
+        to determine which version of the orchestrator function is being executed.
+
+        Returns
+        -------
+        Optional[str]
+            The version of the orchestration instance, or None if not set.
+        """
+        pass
+
+    @property
+    @abstractmethod
     def current_utc_datetime(self) -> datetime:
         """Get the current date/time as UTC.
 

--- a/durabletask/task.py
+++ b/durabletask/task.py
@@ -126,7 +126,8 @@ class OrchestrationContext(ABC):
     def call_sub_orchestrator(self, orchestrator: Orchestrator[TInput, TOutput], *,
                               input: Optional[TInput] = None,
                               instance_id: Optional[str] = None,
-                              retry_policy: Optional[RetryPolicy] = None) -> Task[TOutput]:
+                              retry_policy: Optional[RetryPolicy] = None,
+                              version: Optional[str] = None) -> Task[TOutput]:
         """Schedule sub-orchestrator function for execution.
 
         Parameters

--- a/durabletask/worker.py
+++ b/durabletask/worker.py
@@ -573,7 +573,7 @@ class TaskHubGrpcWorker:
                 customStatus=ph.get_string_value(result.encoded_custom_status),
                 completionToken=completionToken,
             )
-        except pe.AbandonOrchestrationError as ex:
+        except pe.AbandonOrchestrationError:
             self._logger.info(
                 f"Abandoning orchestration. InstanceId = '{req.instanceId}'. Completion token = '{completionToken}'"
             )

--- a/durabletask/worker.py
+++ b/durabletask/worker.py
@@ -561,7 +561,7 @@ class TaskHubGrpcWorker:
             completionToken,
     ):
         try:
-            executor = _OrchestrationExecutor(self._registry, self._logger, stub)
+            executor = _OrchestrationExecutor(self._registry, self._logger)
             result = executor.execute(req.instanceId, req.pastEvents, req.newEvents)
             res = pb.OrchestratorResponse(
                 instanceId=req.instanceId,
@@ -947,12 +947,11 @@ class ExecutionResults:
 class _OrchestrationExecutor:
     _generator: Optional[task.Orchestrator] = None
 
-    def __init__(self, registry: _Registry, logger: logging.Logger, stub: stubs.TaskHubSidecarServiceStub):
+    def __init__(self, registry: _Registry, logger: logging.Logger):
         self._registry = registry
         self._logger = logger
         self._is_suspended = False
         self._suspended_events: list[pb.HistoryEvent] = []
-        self._stub = stub
 
     def execute(
             self,

--- a/durabletask/worker.py
+++ b/durabletask/worker.py
@@ -90,10 +90,6 @@ class VersionFailureStrategy(Enum):
     FAIL = 2
 
 
-class VersionFailureException(Exception):
-    pass
-
-
 class VersioningOptions:
     """Configuration options for orchestrator and activity versioning.
 
@@ -994,7 +990,7 @@ class _OrchestrationExecutor:
                         f"Error action = '{self._registry.versioning.failure_strategy}'. "
                         f"Version error = '{version_failure}'"
                     )
-                    raise VersionFailureException
+                    raise pe.VersionFailureException
 
             # Get new actions by executing newly received events into the orchestrator function
             if self._logger.level <= logging.DEBUG:
@@ -1006,7 +1002,7 @@ class _OrchestrationExecutor:
             for new_event in new_events:
                 self.process_event(ctx, new_event)
 
-        except VersionFailureException as ex:
+        except pe.VersionFailureException as ex:
             if self._registry.versioning and self._registry.versioning.failure_strategy == VersionFailureStrategy.FAIL:
                 if version_failure:
                     ctx.set_failed(version_failure)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ readme = "README.md"
 dependencies = [
     "grpcio",
     "protobuf",
-    "asyncio"
+    "asyncio",
+    "packaging"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest
 pytest-cov
 azure-identity
 asyncio
+packaging

--- a/tests/durabletask-azuremanaged/test_dts_orchestration_e2e.py
+++ b/tests/durabletask-azuremanaged/test_dts_orchestration_e2e.py
@@ -13,7 +13,7 @@ from durabletask.azuremanaged.client import DurableTaskSchedulerClient
 from durabletask.azuremanaged.worker import DurableTaskSchedulerWorker
 
 # NOTE: These tests assume a sidecar process is running. Example command:
-#       docker run --name durabletask-sidecar -p 4001:4001 --env 'DURABLETASK_SIDECAR_LOGLEVEL=Debug' --rm cgillum/durabletask-sidecar:latest start --backend Emulator
+#       docker run -i -p 8080:8080 -p 8082:8082 -d mcr.microsoft.com/dts/dts-emulator:latest
 pytestmark = pytest.mark.dts
 
 # Read the environment variables

--- a/tests/durabletask-azuremanaged/test_dts_orchestration_versioning_e2e.py
+++ b/tests/durabletask-azuremanaged/test_dts_orchestration_versioning_e2e.py
@@ -11,7 +11,7 @@ from durabletask.azuremanaged.client import DurableTaskSchedulerClient
 from durabletask.azuremanaged.worker import DurableTaskSchedulerWorker
 
 # NOTE: These tests assume a sidecar process is running. Example command:
-#       docker run --name durabletask-sidecar -p 4001:4001 --env 'DURABLETASK_SIDECAR_LOGLEVEL=Debug' --rm cgillum/durabletask-sidecar:latest start --backend Emulator
+#       docker run -i -p 8080:8080 -p 8082:8082 -d mcr.microsoft.com/dts/dts-emulator:latest
 pytestmark = pytest.mark.dts
 
 # Read the environment variables

--- a/tests/durabletask-azuremanaged/test_dts_orchestration_versioning_e2e.py
+++ b/tests/durabletask-azuremanaged/test_dts_orchestration_versioning_e2e.py
@@ -1,0 +1,262 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import json
+import os
+
+import pytest
+
+from durabletask import client, task, worker
+from durabletask.azuremanaged.client import DurableTaskSchedulerClient
+from durabletask.azuremanaged.worker import DurableTaskSchedulerWorker
+
+# NOTE: These tests assume a sidecar process is running. Example command:
+#       docker run --name durabletask-sidecar -p 4001:4001 --env 'DURABLETASK_SIDECAR_LOGLEVEL=Debug' --rm cgillum/durabletask-sidecar:latest start --backend Emulator
+pytestmark = pytest.mark.dts
+
+# Read the environment variables
+taskhub_name = os.getenv("TASKHUB", "default")
+endpoint = os.getenv("ENDPOINT", "http://localhost:8080")
+
+
+def plus_one(_: task.ActivityContext, input: int) -> int:
+    return input + 1
+
+
+def single_activity(ctx: task.OrchestrationContext, start_val: int):
+    yield ctx.call_activity(plus_one, input=start_val)
+    return "Success"
+
+
+def sequence(ctx: task.OrchestrationContext, start_val: int):
+    numbers = [start_val]
+    current = start_val
+    for _ in range(10):
+        current = yield ctx.call_activity(plus_one, input=current)
+        numbers.append(current)
+    return numbers
+
+
+def test_versioned_orchestration_succeeds():
+    # Start a worker, which will connect to the sidecar in a background thread
+    with DurableTaskSchedulerWorker(host_address=endpoint, secure_channel=True,
+                                    taskhub=taskhub_name, token_credential=None) as w:
+        w.add_orchestrator(sequence)
+        w.add_activity(plus_one)
+        w.use_versioning(worker.VersioningOptions(
+            version="1.0.0",
+            default_version="1.0.0",
+            match_strategy=worker.VersionMatchStrategy.CURRENT_OR_OLDER,
+            failure_strategy=worker.VersionFailureStrategy.FAIL
+        ))
+        w.start()
+
+        task_hub_client = DurableTaskSchedulerClient(host_address=endpoint, secure_channel=True,
+                                                     taskhub=taskhub_name, token_credential=None,
+                                                     default_version="1.0.0")
+        id = task_hub_client.schedule_new_orchestration(sequence, input=1, version="1.0.0")
+        state = task_hub_client.wait_for_orchestration_completion(
+            id, timeout=30)
+
+    assert state is not None
+    assert state.name == task.get_name(sequence)
+    assert state.instance_id == id
+    assert state.runtime_status == client.OrchestrationStatus.COMPLETED
+    assert state.failure_details is None
+    assert state.serialized_input == json.dumps(1)
+    assert state.serialized_output == json.dumps([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+    assert state.serialized_custom_status is None
+
+
+def test_lower_version_worker_fails():
+    # Start a worker, which will connect to the sidecar in a background thread
+    with DurableTaskSchedulerWorker(host_address=endpoint, secure_channel=True,
+                                    taskhub=taskhub_name, token_credential=None) as w:
+        w.add_orchestrator(single_activity)
+        w.use_versioning(worker.VersioningOptions(
+            version="1.0.0",
+            default_version="1.0.0",
+            match_strategy=worker.VersionMatchStrategy.CURRENT_OR_OLDER,
+            failure_strategy=worker.VersionFailureStrategy.FAIL
+        ))
+        w.start()
+
+        task_hub_client = DurableTaskSchedulerClient(host_address=endpoint, secure_channel=True,
+                                                     taskhub=taskhub_name, token_credential=None,
+                                                     default_version="1.0.0")
+        id = task_hub_client.schedule_new_orchestration(single_activity, input=1, version="1.1.0")
+        state = task_hub_client.wait_for_orchestration_completion(
+            id, timeout=30)
+
+    assert state is not None
+    assert state.name == task.get_name(single_activity)
+    assert state.instance_id == id
+    assert state.runtime_status == client.OrchestrationStatus.FAILED
+    assert state.failure_details is not None
+    assert state.failure_details.message.find("The orchestration version '1.1.0' is greater than the worker version '1.0.0'.") >= 0
+
+
+def test_lower_version_worker_no_match_strategy_succeeds():
+    # Start a worker, which will connect to the sidecar in a background thread
+    with DurableTaskSchedulerWorker(host_address=endpoint, secure_channel=True,
+                                    taskhub=taskhub_name, token_credential=None) as w:
+        w.add_orchestrator(single_activity)
+        w.add_activity(plus_one)
+        w.use_versioning(worker.VersioningOptions(
+            version="1.0.0",
+            default_version="1.0.0",
+            match_strategy=worker.VersionMatchStrategy.NONE,
+            failure_strategy=worker.VersionFailureStrategy.FAIL
+        ))
+        w.start()
+
+        task_hub_client = DurableTaskSchedulerClient(host_address=endpoint, secure_channel=True,
+                                                     taskhub=taskhub_name, token_credential=None,
+                                                     default_version="1.0.0")
+        id = task_hub_client.schedule_new_orchestration(single_activity, input=1, version="1.1.0")
+        state = task_hub_client.wait_for_orchestration_completion(
+            id, timeout=30)
+
+    assert state is not None
+    assert state.name == task.get_name(single_activity)
+    assert state.instance_id == id
+    assert state.runtime_status == client.OrchestrationStatus.COMPLETED
+    assert state.failure_details is None
+
+
+def test_upper_version_worker_succeeds():
+    # Start a worker, which will connect to the sidecar in a background thread
+    with DurableTaskSchedulerWorker(host_address=endpoint, secure_channel=True,
+                                    taskhub=taskhub_name, token_credential=None) as w:
+        w.add_orchestrator(single_activity)
+        w.add_activity(plus_one)
+        w.use_versioning(worker.VersioningOptions(
+            version="1.1.0",
+            default_version="1.1.0",
+            match_strategy=worker.VersionMatchStrategy.CURRENT_OR_OLDER,
+            failure_strategy=worker.VersionFailureStrategy.FAIL
+        ))
+        w.start()
+
+        task_hub_client = DurableTaskSchedulerClient(host_address=endpoint, secure_channel=True,
+                                                     taskhub=taskhub_name, token_credential=None,
+                                                     default_version="1.1.0")
+        id = task_hub_client.schedule_new_orchestration(single_activity, input=1, version="1.0.0")
+        state = task_hub_client.wait_for_orchestration_completion(
+            id, timeout=30)
+
+    assert state is not None
+    assert state.name == task.get_name(single_activity)
+    assert state.instance_id == id
+    assert state.runtime_status == client.OrchestrationStatus.COMPLETED
+    assert state.failure_details is None
+
+
+def test_upper_version_worker_strict_fails():
+    # Start a worker, which will connect to the sidecar in a background thread
+    with DurableTaskSchedulerWorker(host_address=endpoint, secure_channel=True,
+                                    taskhub=taskhub_name, token_credential=None) as w:
+        w.add_orchestrator(single_activity)
+        w.add_activity(plus_one)
+        w.use_versioning(worker.VersioningOptions(
+            version="1.1.0",
+            default_version="1.1.0",
+            match_strategy=worker.VersionMatchStrategy.STRICT,
+            failure_strategy=worker.VersionFailureStrategy.FAIL
+        ))
+        w.start()
+
+        task_hub_client = DurableTaskSchedulerClient(host_address=endpoint, secure_channel=True,
+                                                     taskhub=taskhub_name, token_credential=None,
+                                                     default_version="1.1.0")
+        id = task_hub_client.schedule_new_orchestration(single_activity, input=1, version="1.0.0")
+        state = task_hub_client.wait_for_orchestration_completion(
+            id, timeout=30)
+
+    assert state is not None
+    assert state.name == task.get_name(single_activity)
+    assert state.instance_id == id
+    assert state.runtime_status == client.OrchestrationStatus.FAILED
+    assert state.failure_details is not None
+    assert state.failure_details.message.find("The orchestration version '1.0.0' does not match the worker version '1.1.0'.") >= 0
+
+
+def sequence_suborchestator(ctx: task.OrchestrationContext, start_val: int):
+    numbers = []
+    for current in range(start_val, start_val + 5):
+        current = yield ctx.call_activity(plus_one, input=current)
+        numbers.append(current)
+    return numbers
+
+
+def sequence_parent(ctx: task.OrchestrationContext, sub_orchestration_version: str):
+    tasks = []
+    for current in range(2):
+        tasks.append(ctx.call_sub_orchestrator(sequence_suborchestator, input=current * 5, version=sub_orchestration_version))
+    results = yield task.when_all(tasks)
+    numbers = []
+    for result in results:
+        numbers.extend(result)
+    return numbers
+
+
+def test_versioned_sub_orchestration_succeeds():
+    # Start a worker, which will connect to the sidecar in a background thread
+    with DurableTaskSchedulerWorker(host_address=endpoint, secure_channel=True,
+                                    taskhub=taskhub_name, token_credential=None) as w:
+        w.add_orchestrator(sequence_parent)
+        w.add_orchestrator(sequence_suborchestator)
+        w.add_activity(plus_one)
+        w.use_versioning(worker.VersioningOptions(
+            version="1.0.0",
+            default_version="1.0.0",
+            match_strategy=worker.VersionMatchStrategy.CURRENT_OR_OLDER,
+            failure_strategy=worker.VersionFailureStrategy.FAIL
+        ))
+        w.start()
+
+        task_hub_client = DurableTaskSchedulerClient(host_address=endpoint, secure_channel=True,
+                                                     taskhub=taskhub_name, token_credential=None,
+                                                     default_version="1.0.0")
+        id = task_hub_client.schedule_new_orchestration(sequence_parent, input='1.0.0', version="1.0.0")
+        state = task_hub_client.wait_for_orchestration_completion(
+            id, timeout=30)
+
+    assert state is not None
+    assert state.name == task.get_name(sequence_parent)
+    assert state.instance_id == id
+    assert state.runtime_status == client.OrchestrationStatus.COMPLETED
+    assert state.failure_details is None
+    assert state.serialized_input == json.dumps("1.0.0")
+    assert state.serialized_output == json.dumps([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    assert state.serialized_custom_status is None
+
+
+def test_higher_versioned_sub_orchestration_fails():
+    # Start a worker, which will connect to the sidecar in a background thread
+    with DurableTaskSchedulerWorker(host_address=endpoint, secure_channel=True,
+                                    taskhub=taskhub_name, token_credential=None) as w:
+        w.add_orchestrator(sequence_parent)
+        w.add_orchestrator(sequence_suborchestator)
+        w.add_activity(plus_one)
+        w.use_versioning(worker.VersioningOptions(
+            version="1.0.0",
+            default_version="1.0.0",
+            match_strategy=worker.VersionMatchStrategy.CURRENT_OR_OLDER,
+            failure_strategy=worker.VersionFailureStrategy.FAIL
+        ))
+        w.start()
+
+        task_hub_client = DurableTaskSchedulerClient(host_address=endpoint, secure_channel=True,
+                                                     taskhub=taskhub_name, token_credential=None,
+                                                     default_version="1.0.0")
+        id = task_hub_client.schedule_new_orchestration(sequence_parent, input='1.1.0', version="1.0.0")
+        state = task_hub_client.wait_for_orchestration_completion(
+            id, timeout=30)
+
+    assert state is not None
+    assert state.name == task.get_name(sequence_parent)
+    assert state.instance_id == id
+    assert state.runtime_status == client.OrchestrationStatus.FAILED
+    assert state.failure_details is not None
+    assert state.failure_details.message.find("The orchestration version '1.1.0' is greater than the worker version '1.0.0'.") >= 0

--- a/tests/durabletask/test_orchestration_e2e.py
+++ b/tests/durabletask/test_orchestration_e2e.py
@@ -11,7 +11,8 @@ import pytest
 from durabletask import client, task, worker
 
 # NOTE: These tests assume a sidecar process is running. Example command:
-#       docker run --name durabletask-sidecar -p 4001:4001 --env 'DURABLETASK_SIDECAR_LOGLEVEL=Debug' --rm cgillum/durabletask-sidecar:latest start --backend Emulator
+#       go install github.com/microsoft/durabletask-go@main
+#       durabletask-go --port 4001
 pytestmark = pytest.mark.e2e
 
 

--- a/tests/durabletask/test_orchestration_versioning_e2e.py
+++ b/tests/durabletask/test_orchestration_versioning_e2e.py
@@ -1,0 +1,54 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import json
+
+import pytest
+
+from durabletask import client, task, worker
+
+# NOTE: These tests assume a sidecar process is running. Example command:
+#       docker run --name durabletask-sidecar -p 4001:4001 --env 'DURABLETASK_SIDECAR_LOGLEVEL=Debug' --rm cgillum/durabletask-sidecar:latest start --backend Emulator
+pytestmark = pytest.mark.e2e
+
+
+def test_versioned_orchestration_succeeds():
+    return  # Currently not passing as the sidecar does not support versioning yet
+    # Remove these lines to run the test after the sidecar is updated
+
+    def plus_one(_: task.ActivityContext, input: int) -> int:
+        return input + 1
+
+    def sequence(ctx: task.OrchestrationContext, start_val: int):
+        numbers = [start_val]
+        current = start_val
+        for _ in range(10):
+            current = yield ctx.call_activity(plus_one, input=current, tags={'Activity': 'PlusOne'})
+            numbers.append(current)
+        return numbers
+
+    # Start a worker, which will connect to the sidecar in a background thread
+    with worker.TaskHubGrpcWorker() as w:
+        w.add_orchestrator(sequence)
+        w.add_activity(plus_one)
+        w.use_versioning(worker.VersioningOptions(
+            version="1.0.0",
+            default_version="1.0.0",
+            match_strategy=worker.VersionMatchStrategy.CURRENT_OR_OLDER,
+            failure_strategy=worker.VersionFailureStrategy.FAIL
+        ))
+        w.start()
+
+        task_hub_client = client.TaskHubGrpcClient(default_version="1.0.0")
+        id = task_hub_client.schedule_new_orchestration(sequence, input=1, tags={'Orchestration': 'Sequence'}, version="1.0.0")
+        state = task_hub_client.wait_for_orchestration_completion(
+            id, timeout=30)
+
+    assert state is not None
+    assert state.name == task.get_name(sequence)
+    assert state.instance_id == id
+    assert state.runtime_status == client.OrchestrationStatus.COMPLETED
+    assert state.failure_details is None
+    assert state.serialized_input == json.dumps(1)
+    assert state.serialized_output == json.dumps([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+    assert state.serialized_custom_status is None

--- a/tests/durabletask/test_orchestration_versioning_e2e.py
+++ b/tests/durabletask/test_orchestration_versioning_e2e.py
@@ -2,17 +2,21 @@
 # Licensed under the MIT License.
 
 import json
+import warnings
 
 import pytest
 
 from durabletask import client, task, worker
 
 # NOTE: These tests assume a sidecar process is running. Example command:
-#       docker run --name durabletask-sidecar -p 4001:4001 --env 'DURABLETASK_SIDECAR_LOGLEVEL=Debug' --rm cgillum/durabletask-sidecar:latest start --backend Emulator
+#       go install github.com/microsoft/durabletask-go@main
+#       durabletask-go --port 4001
 pytestmark = pytest.mark.e2e
 
 
 def test_versioned_orchestration_succeeds():
+    warnings.warn("Skipping test_versioned_orchestration_succeeds. "
+                  "Currently not passing as the sidecar does not support versioning yet")
     return  # Currently not passing as the sidecar does not support versioning yet
     # Remove these lines to run the test after the sidecar is updated
 


### PR DESCRIPTION
Adds orchestration versioning support

Syntax: 

To add a versioning strategy to the worker: 
```python
    with DurableTaskSchedulerWorker(host_address=endpoint, secure_channel=True,
                                    taskhub=taskhub_name, token_credential=None) as w:
        w.add_orchestrator(single_activity)
        w.add_activity(plus_one)
        w.use_versioning(worker.VersioningOptions(
            version="1.0.0",
            default_version="1.0.0",
            match_strategy=worker.VersionMatchStrategy.CURRENT_OR_OLDER,
            failure_strategy=worker.VersionFailureStrategy.FAIL
        ))
        w.start()
```

To add a default version to the client (version to use when scheduling new orchestrations): 
```python
        task_hub_client = client.TaskHubGrpcClient(default_version="1.0.0")
```

To schedule an orchestration with a manual version: 
```python
        id = task_hub_client.schedule_new_orchestration(sequence, input=1, version="1.0.0")
```

To schedule a sub-orchestration with a manual version: 
```python
        yield ctx.call_sub_orchestrator(sequence_suborchestator, input=1, version='1.0.0')
```