### PR TITLE
Match entity method parameter names

### DIFF
--- a/durabletask/task.py
+++ b/durabletask/task.py
@@ -139,7 +139,8 @@ class OrchestrationContext(ABC):
         pass
 
     @abstractmethod
-    def call_entity(self, entity: EntityInstanceId,
+    def call_entity(self,
+                    entity: EntityInstanceId,
                     operation: str,
                     input: Optional[TInput] = None) -> Task:
         """Schedule entity function for execution.

--- a/durabletask/worker.py
+++ b/durabletask/worker.py
@@ -1038,14 +1038,14 @@ class _RuntimeOrchestrationContext(task.OrchestrationContext):
 
     def call_entity(
             self,
-            entity_id: EntityInstanceId,
+            entity: EntityInstanceId,
             operation: str,
             input: Optional[TInput] = None,
     ) -> task.Task:
         id = self.next_sequence_number()
 
         self.call_entity_function_helper(
-            id, entity_id, operation, input=input
+            id, entity, operation, input=input
         )
 
         return self._pending_tasks.get(id, task.CompletableTask())
@@ -1053,13 +1053,13 @@ class _RuntimeOrchestrationContext(task.OrchestrationContext):
     def signal_entity(
             self,
             entity_id: EntityInstanceId,
-            operation: str,
+            operation_name: str,
             input: Optional[TInput] = None
     ) -> None:
         id = self.next_sequence_number()
 
         self.signal_entity_function_helper(
-            id, entity_id, operation, input
+            id, entity_id, operation_name, input
         )
 
     def lock_entities(self, entities: list[EntityInstanceId]) -> task.Task[EntityLock]:


### PR DESCRIPTION
Ensure consistency in worker.py to task.py - currently the overrides in worker.py are incompatible with the base methods in task.py due to the parameter names being different. 
This one irks me because when I implemented this, I was inconsistent between call_entity and signal_entity, but any change in task.py is a breaking change