### PR TITLE
Improve entity typing support

### DIFF
--- a/durabletask/client.py
+++ b/durabletask/client.py
@@ -11,8 +11,7 @@ from typing import Any, Optional, Sequence, TypeVar, Union
 import grpc
 from google.protobuf import wrappers_pb2
 
-from durabletask.entities import EntityInstanceId
-from durabletask.entities.entity_metadata import EntityMetadata
+from durabletask.entities import EntityInstanceId, EntityMetadata
 import durabletask.internal.helpers as helpers
 import durabletask.internal.orchestrator_service_pb2 as pb
 import durabletask.internal.orchestrator_service_pb2_grpc as stubs
@@ -230,7 +229,10 @@ class TaskHubGrpcClient:
         self._logger.info(f"Purging instance '{instance_id}'.")
         self._stub.PurgeInstances(req)
 
-    def signal_entity(self, entity_instance_id: EntityInstanceId, operation_name: str, input: Optional[Any] = None):
+    def signal_entity(self,
+                      entity_instance_id: EntityInstanceId[TInput, TOutput],
+                      operation_name: str,
+                      input: Optional[TInput] = None):
         req = pb.SignalEntityRequest(
             instanceId=str(entity_instance_id),
             name=operation_name,
@@ -244,7 +246,7 @@ class TaskHubGrpcClient:
         self._stub.SignalEntity(req, None)  # TODO: Cancellation timeout?
 
     def get_entity(self,
-                   entity_instance_id: EntityInstanceId,
+                   entity_instance_id: EntityInstanceId[Any, Any],
                    include_state: bool = True
                    ) -> Optional[EntityMetadata]:
         req = pb.GetEntityRequest(instanceId=str(entity_instance_id), includeState=include_state)

--- a/durabletask/entities/durable_entity.py
+++ b/durabletask/entities/durable_entity.py
@@ -4,6 +4,7 @@ from durabletask.entities.entity_context import EntityContext
 from durabletask.entities.entity_instance_id import EntityInstanceId
 
 TState = TypeVar("TState")
+TInput = TypeVar("TInput")
 
 
 class DurableEntity:
@@ -49,7 +50,10 @@ class DurableEntity:
         """
         self.entity_context.set_state(state)
 
-    def signal_entity(self, entity_instance_id: EntityInstanceId, operation: str, input: Optional[Any] = None) -> None:
+    def signal_entity(self,
+                      entity_instance_id: EntityInstanceId[TInput, Any],
+                      operation: str,
+                      input: Optional[TInput] = None) -> None:
         """Signal another entity to perform an operation.
 
         Parameters

--- a/durabletask/entities/entity_context.py
+++ b/durabletask/entities/entity_context.py
@@ -7,6 +7,7 @@ from durabletask.internal.entity_state_shim import StateShim
 import durabletask.internal.orchestrator_service_pb2 as pb
 
 TState = TypeVar("TState")
+TInput = TypeVar("TInput")
 
 
 class EntityContext:
@@ -81,7 +82,7 @@ class EntityContext:
         """
         self._state.set_state(new_state)
 
-    def signal_entity(self, entity_instance_id: EntityInstanceId, operation: str, input: Optional[Any] = None) -> None:
+    def signal_entity(self, entity_instance_id: EntityInstanceId[TInput, Any], operation: str, input: Optional[TInput] = None) -> None:
         """Signal another entity to perform an operation.
 
         Parameters

--- a/durabletask/entities/entity_instance_id.py
+++ b/durabletask/entities/entity_instance_id.py
@@ -1,7 +1,54 @@
-class EntityInstanceId:
-    def __init__(self, entity: str, key: str):
-        self.entity = entity
-        self.key = key
+from typing import Any, Callable, TypeVar, Union, overload, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from durabletask import task
+    from durabletask.entities.durable_entity import DurableEntity
+    from durabletask.entities.entity_context import EntityContext
+
+
+TInput = TypeVar('TInput')
+TOutput = TypeVar('TOutput')
+
+
+class EntityInstanceId[TInput, TOutput]:
+    @overload
+    def __new__(
+        cls,
+        entity: Callable[[EntityContext, TInput], TOutput],
+        key: str
+    ) -> "EntityInstanceId[TInput, TOutput]": ...
+
+    @overload
+    def __new__(
+        cls,
+        entity: type[DurableEntity],
+        key: str
+    ) -> "EntityInstanceId[Any, Any]": ...
+
+    @overload
+    def __new__(
+        cls,
+        entity: str,
+        key: str
+    ) -> "EntityInstanceId[Any, Any]": ...
+
+    def __new__(
+        cls,
+        entity: Union[task.Entity[TInput, TOutput], str],
+        key: str
+    ) -> "EntityInstanceId[Any, Any]":
+        return super().__new__(cls)
+
+    def __init__(
+        self,
+        entity: Union[task.Entity[TInput, TOutput], str],
+        key: str
+    ):
+        if not isinstance(entity, str):
+            from durabletask import task
+            entity = task.get_entity_name(entity)
+        self.entity: str = entity
+        self.key: str = key
 
     def __str__(self) -> str:
         return f"@{self.entity}@{self.key}"
@@ -17,7 +64,7 @@ class EntityInstanceId:
         return str(self) < str(other)
 
     @staticmethod
-    def parse(entity_id: str) -> "EntityInstanceId":
+    def parse(entity_id: str) -> "EntityInstanceId[Any, Any]":
         """Parse a string representation of an entity ID into an EntityInstanceId object.
 
         Parameters

--- a/durabletask/entities/entity_metadata.py
+++ b/durabletask/entities/entity_metadata.py
@@ -24,7 +24,7 @@ class EntityMetadata:
     """
 
     def __init__(self,
-                 id: EntityInstanceId,
+                 id: EntityInstanceId[Any, Any],
                  last_modified: datetime,
                  backlog_queue_size: int,
                  locked_by: str,


### PR DESCRIPTION
This PR aims to improve type-hinting for entities by adding the following behaviors: 

1. EntityInstanceId objects may be instantiated with either the entity _name_ or the entity _method/class_ for function/class-based entities respectively. 
2. EntityInstanceId objects are type-hinted to the input and output types for the entity. Type-hinting an EntityInstanceId will be done automatically in the case of class-based entities initialized with the method, or manually in the case of EntityInstanceIds initialized using the name or class-based entity:  
```python
    instance_id_2 = EntityInstanceId(testEntity, 'instance')

    instance_id_1: EntityInstanceId[int, int] = EntityInstanceId(TestEntity, 'instance')
    instance_id_1: EntityInstanceId[int, int] = EntityInstanceId('TestEntity', 'instance')
```
3. Entities may be registered with a custom name, and this name will be respected by EntityInstanceIds initialized using the method/class
    1. NOTE: If the EntityInstanceId is constructed _before_ the entity is registered by the worker, such as in a global scope, this name lookup will fail
4. Methods like call_entity, signal_entity will type-hint based on the EntityInstanceId they are provided. This supports type-checking the input to the entities and correctly type-hinting the output
    1. NOTE: For Task-based entity operations (context.call_entity() in RuntimeOrchestrationContext), the Task is correctly type-hinted but since the type-checker has no way to know that yielding a Task[int] will return an int, the typing breaks down in this case. Example: 
```python
def entity_orchestration(context: OrchestrationContext, _) -> int:
    instance_id_1: EntityInstanceId[int, int] = EntityInstanceId(TestEntity, 'instance')
    
    context.signal_entity(instance_id_1, 'SetState', 42)
    # task is typehinted Task[int]
    task = context.call_entity(instance_id_1, 'GetState')
    # r_1 is typehinted Unknown
    r_1 = yield task

    # Type-hinting complains returning wrong type
    return r_1
```
