### PR TITLE
feat: gRPC interceptor improvements (channel options, retry policy, custom channel, workerid, thread safety)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+ADDED
+
+- Added `GrpcChannelOptions` and `GrpcRetryPolicyOptions` for configuring
+  gRPC transport behavior, including message-size limits, keepalive settings,
+  and channel-level retry policy service configuration.
+- Added optional `channel` and `channel_options` parameters to
+  `TaskHubGrpcClient`, `AsyncTaskHubGrpcClient`, and `TaskHubGrpcWorker` to
+  support pre-configured channel passthrough and low-level gRPC channel
+  customization.
+
 ## v1.4.0
 
 ADDED

--- a/durabletask-azuremanaged/CHANGELOG.md
+++ b/durabletask-azuremanaged/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Added optional `interceptors`, `channel`, and `channel_options` parameters to
+  `DurableTaskSchedulerClient`, `AsyncDurableTaskSchedulerClient`, and
+  `DurableTaskSchedulerWorker` to allow combining custom gRPC interceptors with
+  DTS defaults and to support pre-configured/customized gRPC channels.
+- Added `workerid` gRPC metadata on Durable Task Scheduler worker calls for
+  improved worker identity and observability.
+- Improved sync access token refresh concurrency handling to avoid duplicate
+  refresh operations under concurrent access.
+
 ## v1.4.0
 
 - Updates base dependency to durabletask v1.4.0

--- a/durabletask-azuremanaged/durabletask/azuremanaged/client.py
+++ b/durabletask-azuremanaged/durabletask/azuremanaged/client.py
@@ -3,8 +3,10 @@
 
 import logging
 
-from typing import Optional
+from typing import Optional, Sequence
 
+import grpc
+import grpc.aio
 from azure.core.credentials import TokenCredential
 from azure.core.credentials_async import AsyncTokenCredential
 
@@ -13,6 +15,8 @@ from durabletask.azuremanaged.internal.durabletask_grpc_interceptor import (
     DTSDefaultClientInterceptorImpl,
 )
 from durabletask.client import AsyncTaskHubGrpcClient, TaskHubGrpcClient
+from durabletask.grpc_options import GrpcChannelOptions
+import durabletask.internal.shared as shared
 from durabletask.payload.store import PayloadStore
 
 
@@ -22,7 +26,10 @@ class DurableTaskSchedulerClient(TaskHubGrpcClient):
                  host_address: str,
                  taskhub: str,
                  token_credential: Optional[TokenCredential],
+                 channel: Optional[grpc.Channel] = None,
                  secure_channel: bool = True,
+                 interceptors: Optional[Sequence[shared.ClientInterceptor]] = None,
+                 channel_options: Optional[GrpcChannelOptions] = None,
                  default_version: Optional[str] = None,
                  payload_store: Optional[PayloadStore] = None,
                  log_handler: Optional[logging.Handler] = None,
@@ -31,17 +38,22 @@ class DurableTaskSchedulerClient(TaskHubGrpcClient):
         if not taskhub:
             raise ValueError("Taskhub value cannot be empty. Please provide a value for your taskhub")
 
-        interceptors = [DTSDefaultClientInterceptorImpl(token_credential, taskhub)]
+        resolved_interceptors: list[shared.ClientInterceptor] = (
+            list(interceptors) if interceptors is not None else []
+        )
+        resolved_interceptors.append(DTSDefaultClientInterceptorImpl(token_credential, taskhub))
 
         # We pass in None for the metadata so we don't construct an additional interceptor in the parent class
         # Since the parent class doesn't use anything metadata for anything else, we can set it as None
         super().__init__(
             host_address=host_address,
+            channel=channel,
             secure_channel=secure_channel,
             metadata=None,
             log_handler=log_handler,
             log_formatter=log_formatter,
-            interceptors=interceptors,
+            interceptors=resolved_interceptors,
+            channel_options=channel_options,
             default_version=default_version,
             payload_store=payload_store)
 
@@ -88,7 +100,10 @@ class AsyncDurableTaskSchedulerClient(AsyncTaskHubGrpcClient):
                  host_address: str,
                  taskhub: str,
                  token_credential: Optional[AsyncTokenCredential],
+                 channel: Optional[grpc.aio.Channel] = None,
                  secure_channel: bool = True,
+                 interceptors: Optional[Sequence[shared.AsyncClientInterceptor]] = None,
+                 channel_options: Optional[GrpcChannelOptions] = None,
                  default_version: Optional[str] = None,
                  payload_store: Optional[PayloadStore] = None,
                  log_handler: Optional[logging.Handler] = None,
@@ -97,16 +112,21 @@ class AsyncDurableTaskSchedulerClient(AsyncTaskHubGrpcClient):
         if not taskhub:
             raise ValueError("Taskhub value cannot be empty. Please provide a value for your taskhub")
 
-        interceptors = [DTSAsyncDefaultClientInterceptorImpl(token_credential, taskhub)]
+        resolved_interceptors: list[shared.AsyncClientInterceptor] = (
+            list(interceptors) if interceptors is not None else []
+        )
+        resolved_interceptors.append(DTSAsyncDefaultClientInterceptorImpl(token_credential, taskhub))
 
         # We pass in None for the metadata so we don't construct an additional interceptor in the parent class
         # Since the parent class doesn't use anything metadata for anything else, we can set it as None
         super().__init__(
             host_address=host_address,
+            channel=channel,
             secure_channel=secure_channel,
             metadata=None,
             log_handler=log_handler,
             log_formatter=log_formatter,
-            interceptors=interceptors,
+            interceptors=resolved_interceptors,
+            channel_options=channel_options,
             default_version=default_version,
             payload_store=payload_store)

--- a/durabletask-azuremanaged/durabletask/azuremanaged/internal/access_token_manager.py
+++ b/durabletask-azuremanaged/durabletask/azuremanaged/internal/access_token_manager.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 from datetime import datetime, timedelta, timezone
+from threading import Lock
 from typing import Optional
 
 from azure.core.credentials import AccessToken, TokenCredential
@@ -20,6 +21,7 @@ class AccessTokenManager:
         self._logger = shared.get_logger("token_manager")
 
         self._credential = token_credential
+        self._refresh_lock = Lock()
 
         if self._credential is not None:
             self._token = self._credential.get_token(self._scope)
@@ -30,7 +32,9 @@ class AccessTokenManager:
 
     def get_access_token(self) -> Optional[AccessToken]:
         if self._token is None or self.is_token_expired():
-            self.refresh_token()
+            with self._refresh_lock:
+                if self._token is None or self.is_token_expired():
+                    self.refresh_token()
         return self._token
 
     # Checks if the token is expired, or if it will expire in the next "refresh_interval_seconds" seconds.

--- a/durabletask-azuremanaged/durabletask/azuremanaged/internal/durabletask_grpc_interceptor.py
+++ b/durabletask-azuremanaged/durabletask/azuremanaged/internal/durabletask_grpc_interceptor.py
@@ -25,7 +25,11 @@ class DTSDefaultClientInterceptorImpl (DefaultClientInterceptorImpl):
     StreamUnaryClientInterceptor and StreamStreamClientInterceptor from grpc to add an
     interceptor to add additional headers to all calls as needed."""
 
-    def __init__(self, token_credential: Optional[TokenCredential], taskhub_name: str):
+    def __init__(
+            self,
+            token_credential: Optional[TokenCredential],
+            taskhub_name: str,
+            worker_id: Optional[str] = None):
         try:
             # Get the version of the azuremanaged package
             sdk_version = version('durabletask-azuremanaged')
@@ -35,7 +39,9 @@ class DTSDefaultClientInterceptorImpl (DefaultClientInterceptorImpl):
         user_agent = f"durabletask-python/{sdk_version}"
         self._metadata = [
             ("taskhub", taskhub_name),
-            ("x-user-agent", user_agent)]  # 'user-agent' is a reserved header in grpc, so we use 'x-user-agent' instead
+            ("x-user-agent", user_agent)]  # 'user-agent' is a reserved header; use 'x-user-agent'
+        if worker_id is not None:
+            self._metadata.append(("workerid", worker_id))
         super().__init__(self._metadata)
 
         self._token_manager = None
@@ -44,7 +50,17 @@ class DTSDefaultClientInterceptorImpl (DefaultClientInterceptorImpl):
             self._token_manager = AccessTokenManager(token_credential=self._token_credential)
             access_token = self._token_manager.get_access_token()
             if access_token is not None:
-                self._metadata.append(("authorization", f"Bearer {access_token.token}"))
+                self._upsert_authorization_header(access_token.token)
+
+    def _upsert_authorization_header(self, token: str) -> None:
+        found = False
+        for i, (key, _) in enumerate(self._metadata):
+            if key.lower() == "authorization":
+                self._metadata[i] = ("authorization", f"Bearer {token}")
+                found = True
+                break
+        if not found:
+            self._metadata.append(("authorization", f"Bearer {token}"))
 
     def _intercept_call(
             self, client_call_details: _ClientCallDetails) -> grpc.ClientCallDetails:
@@ -56,15 +72,7 @@ class DTSDefaultClientInterceptorImpl (DefaultClientInterceptorImpl):
         if self._token_manager is not None:
             access_token = self._token_manager.get_access_token()
             if access_token is not None:
-                # Update the existing authorization header
-                found = False
-                for i, (key, _) in enumerate(self._metadata):
-                    if key.lower() == "authorization":
-                        self._metadata[i] = ("authorization", f"Bearer {access_token.token}")
-                        found = True
-                        break
-                if not found:
-                    self._metadata.append(("authorization", f"Bearer {access_token.token}"))
+                self._upsert_authorization_header(access_token.token)
 
         return super()._intercept_call(client_call_details)
 
@@ -96,6 +104,16 @@ class DTSAsyncDefaultClientInterceptorImpl(DefaultAsyncClientInterceptorImpl):
             self._token_credential = token_credential
             self._token_manager = AsyncAccessTokenManager(token_credential=self._token_credential)
 
+    def _upsert_authorization_header(self, token: str) -> None:
+        found = False
+        for i, (key, _) in enumerate(self._metadata):
+            if key.lower() == "authorization":
+                self._metadata[i] = ("authorization", f"Bearer {token}")
+                found = True
+                break
+        if not found:
+            self._metadata.append(("authorization", f"Bearer {token}"))
+
     async def _intercept_call(
             self, client_call_details: _AsyncClientCallDetails) -> grpc.aio.ClientCallDetails:
         """Internal intercept_call implementation which adds metadata to grpc metadata in the RPC
@@ -106,16 +124,6 @@ class DTSAsyncDefaultClientInterceptorImpl(DefaultAsyncClientInterceptorImpl):
         if self._token_manager is not None:
             access_token = await self._token_manager.get_access_token()
             if access_token is not None:
-                # Update the existing authorization header, or append one if this
-                # is the first successful token acquisition (token is lazily
-                # fetched on the first call since async constructors aren't possible).
-                found = False
-                for i, (key, _) in enumerate(self._metadata):
-                    if key.lower() == "authorization":
-                        self._metadata[i] = ("authorization", f"Bearer {access_token.token}")
-                        found = True
-                        break
-                if not found:
-                    self._metadata.append(("authorization", f"Bearer {access_token.token}"))
+                self._upsert_authorization_header(access_token.token)
 
         return await super()._intercept_call(client_call_details)

--- a/durabletask-azuremanaged/durabletask/azuremanaged/worker.py
+++ b/durabletask-azuremanaged/durabletask/azuremanaged/worker.py
@@ -2,13 +2,19 @@
 # Licensed under the MIT License.
 
 import logging
+import os
+import socket
+import uuid
 
-from typing import Optional
+from typing import Optional, Sequence
 
+import grpc
 from azure.core.credentials import TokenCredential
 
 from durabletask.azuremanaged.internal.durabletask_grpc_interceptor import \
     DTSDefaultClientInterceptorImpl
+from durabletask.grpc_options import GrpcChannelOptions
+import durabletask.internal.shared as shared
 from durabletask.payload.store import PayloadStore
 from durabletask.worker import ConcurrencyOptions, TaskHubGrpcWorker
 
@@ -64,7 +70,10 @@ class DurableTaskSchedulerWorker(TaskHubGrpcWorker):
                  host_address: str,
                  taskhub: str,
                  token_credential: Optional[TokenCredential],
+                 channel: Optional[grpc.Channel] = None,
                  secure_channel: bool = True,
+                 interceptors: Optional[Sequence[shared.ClientInterceptor]] = None,
+                 channel_options: Optional[GrpcChannelOptions] = None,
                  concurrency_options: Optional[ConcurrencyOptions] = None,
                  payload_store: Optional[PayloadStore] = None,
                  log_handler: Optional[logging.Handler] = None,
@@ -73,17 +82,25 @@ class DurableTaskSchedulerWorker(TaskHubGrpcWorker):
         if not taskhub:
             raise ValueError("The taskhub value cannot be empty.")
 
-        interceptors = [DTSDefaultClientInterceptorImpl(token_credential, taskhub)]
+        worker_id = f"{socket.gethostname()}:{os.getpid()}:{uuid.uuid4()}"
+        resolved_interceptors: list[shared.ClientInterceptor] = (
+            list(interceptors) if interceptors is not None else []
+        )
+        resolved_interceptors.append(
+            DTSDefaultClientInterceptorImpl(token_credential, taskhub, worker_id=worker_id)
+        )
 
         # We pass in None for the metadata so we don't construct an additional interceptor in the parent class
         # Since the parent class doesn't use anything metadata for anything else, we can set it as None
         super().__init__(
             host_address=host_address,
+            channel=channel,
             secure_channel=secure_channel,
             metadata=None,
             log_handler=log_handler,
             log_formatter=log_formatter,
-            interceptors=interceptors,
+            interceptors=resolved_interceptors,
+            channel_options=channel_options,
             concurrency_options=concurrency_options,
             # DTS natively supports long timers so chunking is unnecessary
             maximum_timer_interval=None,

--- a/durabletask/__init__.py
+++ b/durabletask/__init__.py
@@ -3,6 +3,7 @@
 
 """Durable Task SDK for Python"""
 
+from durabletask.grpc_options import GrpcChannelOptions, GrpcRetryPolicyOptions
 from durabletask.payload.store import LargePayloadStorageOptions, PayloadStore
 from durabletask.worker import (
     ActivityWorkItemFilter,
@@ -17,6 +18,8 @@ __all__ = [
     "ActivityWorkItemFilter",
     "ConcurrencyOptions",
     "EntityWorkItemFilter",
+    "GrpcChannelOptions",
+    "GrpcRetryPolicyOptions",
     "LargePayloadStorageOptions",
     "OrchestrationWorkItemFilter",
     "PayloadStore",

--- a/durabletask/client.py
+++ b/durabletask/client.py
@@ -160,6 +160,7 @@ class TaskHubGrpcClient:
                  default_version: Optional[str] = None,
                  payload_store: Optional[PayloadStore] = None):
 
+        self._owns_channel = channel is None
         if channel is None:
             interceptors = prepare_sync_interceptors(metadata, interceptors)
             channel = shared.get_grpc_channel(
@@ -175,8 +176,15 @@ class TaskHubGrpcClient:
         self._payload_store = payload_store
 
     def close(self) -> None:
-        """Closes the underlying gRPC channel."""
-        self._channel.close()
+        """Closes the underlying gRPC channel.
+
+        Only closes channels created internally. If a pre-configured channel
+        was passed via the ``channel`` constructor parameter, this method is
+        a no-op — the caller retains ownership and is responsible for closing
+        it.
+        """
+        if self._owns_channel:
+            self._channel.close()
 
     def schedule_new_orchestration(self, orchestrator: Union[task.Orchestrator[TInput, TOutput], str], *,
                                    input: Optional[TInput] = None,
@@ -444,6 +452,7 @@ class AsyncTaskHubGrpcClient:
                  default_version: Optional[str] = None,
                  payload_store: Optional[PayloadStore] = None):
 
+        self._owns_channel = channel is None
         if channel is None:
             interceptors = prepare_async_interceptors(metadata, interceptors)
             channel = shared.get_async_grpc_channel(
@@ -459,8 +468,15 @@ class AsyncTaskHubGrpcClient:
         self._payload_store = payload_store
 
     async def close(self) -> None:
-        """Closes the underlying gRPC channel."""
-        await self._channel.close()
+        """Closes the underlying gRPC channel.
+
+        Only closes channels created internally. If a pre-configured channel
+        was passed via the ``channel`` constructor parameter, this method is
+        a no-op — the caller retains ownership and is responsible for closing
+        it.
+        """
+        if self._owns_channel:
+            await self._channel.close()
 
     async def __aenter__(self):
         return self

--- a/durabletask/client.py
+++ b/durabletask/client.py
@@ -13,6 +13,7 @@ import grpc.aio
 
 from durabletask.entities import EntityInstanceId
 from durabletask.entities.entity_metadata import EntityMetadata
+from durabletask.grpc_options import GrpcChannelOptions
 import durabletask.internal.helpers as helpers
 import durabletask.internal.orchestrator_service_pb2 as pb
 import durabletask.internal.orchestrator_service_pb2_grpc as stubs
@@ -152,18 +153,21 @@ class TaskHubGrpcClient:
                  metadata: Optional[list[tuple[str, str]]] = None,
                  log_handler: Optional[logging.Handler] = None,
                  log_formatter: Optional[logging.Formatter] = None,
+                 channel: Optional[grpc.Channel] = None,
                  secure_channel: bool = False,
                  interceptors: Optional[Sequence[shared.ClientInterceptor]] = None,
+                 channel_options: Optional[GrpcChannelOptions] = None,
                  default_version: Optional[str] = None,
                  payload_store: Optional[PayloadStore] = None):
 
-        interceptors = prepare_sync_interceptors(metadata, interceptors)
-
-        channel = shared.get_grpc_channel(
-            host_address=host_address,
-            secure_channel=secure_channel,
-            interceptors=interceptors
-        )
+        if channel is None:
+            interceptors = prepare_sync_interceptors(metadata, interceptors)
+            channel = shared.get_grpc_channel(
+                host_address=host_address,
+                secure_channel=secure_channel,
+                interceptors=interceptors,
+                channel_options=channel_options,
+            )
         self._channel = channel
         self._stub = stubs.TaskHubSidecarServiceStub(channel)
         self._logger = shared.get_logger("client", log_handler, log_formatter)
@@ -433,18 +437,21 @@ class AsyncTaskHubGrpcClient:
                  metadata: Optional[list[tuple[str, str]]] = None,
                  log_handler: Optional[logging.Handler] = None,
                  log_formatter: Optional[logging.Formatter] = None,
+                 channel: Optional[grpc.aio.Channel] = None,
                  secure_channel: bool = False,
                  interceptors: Optional[Sequence[shared.AsyncClientInterceptor]] = None,
+                 channel_options: Optional[GrpcChannelOptions] = None,
                  default_version: Optional[str] = None,
                  payload_store: Optional[PayloadStore] = None):
 
-        interceptors = prepare_async_interceptors(metadata, interceptors)
-
-        channel = shared.get_async_grpc_channel(
-            host_address=host_address,
-            secure_channel=secure_channel,
-            interceptors=interceptors
-        )
+        if channel is None:
+            interceptors = prepare_async_interceptors(metadata, interceptors)
+            channel = shared.get_async_grpc_channel(
+                host_address=host_address,
+                secure_channel=secure_channel,
+                interceptors=interceptors,
+                channel_options=channel_options,
+            )
         self._channel = channel
         self._stub = stubs.TaskHubSidecarServiceStub(channel)
         self._logger = shared.get_logger("async_client", log_handler, log_formatter)

--- a/durabletask/grpc_options.py
+++ b/durabletask/grpc_options.py
@@ -31,10 +31,21 @@ class GrpcRetryPolicyOptions:
             raise ValueError("max_backoff_seconds must be >= initial_backoff_seconds")
         if len(self.retryable_status_codes) == 0:
             raise ValueError("retryable_status_codes cannot be empty")
+        # Validate that backoff values are representable as non-zero gRPC duration strings.
+        self._format_duration(self.initial_backoff_seconds)
+        self._format_duration(self.max_backoff_seconds)
 
     @staticmethod
     def _format_duration(seconds: float) -> str:
-        return f"{seconds:.3f}s"
+        formatted = f"{seconds:.9f}".rstrip('0')
+        if formatted.endswith('.'):
+            formatted += '0'
+        if float(formatted) == 0:
+            raise ValueError(
+                f"Duration {seconds!r} rounds to zero; use a value large enough to "
+                "produce a non-zero gRPC duration string."
+            )
+        return f"{formatted}s"
 
     def to_service_config(self) -> dict[str, Any]:
         return {

--- a/durabletask/grpc_options.py
+++ b/durabletask/grpc_options.py
@@ -1,0 +1,91 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from typing import Any, Optional
+
+
+@dataclass
+class GrpcRetryPolicyOptions:
+    """Configuration for transport-level gRPC retries."""
+
+    max_attempts: int = 4
+    initial_backoff_seconds: float = 0.05
+    max_backoff_seconds: float = 0.25
+    backoff_multiplier: float = 2.0
+    retryable_status_codes: list[str] = field(default_factory=lambda: ["UNAVAILABLE"])
+
+    def __post_init__(self) -> None:
+        if self.max_attempts < 2:
+            raise ValueError("max_attempts must be >= 2")
+        if self.initial_backoff_seconds <= 0:
+            raise ValueError("initial_backoff_seconds must be > 0")
+        if self.max_backoff_seconds <= 0:
+            raise ValueError("max_backoff_seconds must be > 0")
+        if self.backoff_multiplier <= 0:
+            raise ValueError("backoff_multiplier must be > 0")
+        if self.max_backoff_seconds < self.initial_backoff_seconds:
+            raise ValueError("max_backoff_seconds must be >= initial_backoff_seconds")
+        if len(self.retryable_status_codes) == 0:
+            raise ValueError("retryable_status_codes cannot be empty")
+
+    @staticmethod
+    def _format_duration(seconds: float) -> str:
+        return f"{seconds:.3f}s"
+
+    def to_service_config(self) -> dict[str, Any]:
+        return {
+            "methodConfig": [
+                {
+                    "name": [{}],
+                    "retryPolicy": {
+                        "maxAttempts": self.max_attempts,
+                        "initialBackoff": self._format_duration(self.initial_backoff_seconds),
+                        "maxBackoff": self._format_duration(self.max_backoff_seconds),
+                        "backoffMultiplier": self.backoff_multiplier,
+                        "retryableStatusCodes": self.retryable_status_codes,
+                    },
+                }
+            ]
+        }
+
+
+@dataclass
+class GrpcChannelOptions:
+    """Configuration for transport-level gRPC channel behavior."""
+
+    max_receive_message_length: Optional[int] = None
+    max_send_message_length: Optional[int] = None
+    keepalive_time_ms: Optional[int] = None
+    keepalive_timeout_ms: Optional[int] = None
+    keepalive_permit_without_calls: Optional[bool] = None
+    retry_policy: Optional[GrpcRetryPolicyOptions] = None
+    raw_options: list[tuple[str, Any]] = field(default_factory=list)
+
+    def to_grpc_options(self) -> list[tuple[str, Any]]:
+        options = list(self.raw_options)
+
+        if self.max_receive_message_length is not None:
+            options.append(("grpc.max_receive_message_length", self.max_receive_message_length))
+        if self.max_send_message_length is not None:
+            options.append(("grpc.max_send_message_length", self.max_send_message_length))
+        if self.keepalive_time_ms is not None:
+            options.append(("grpc.keepalive_time_ms", self.keepalive_time_ms))
+        if self.keepalive_timeout_ms is not None:
+            options.append(("grpc.keepalive_timeout_ms", self.keepalive_timeout_ms))
+        if self.keepalive_permit_without_calls is not None:
+            options.append(
+                (
+                    "grpc.keepalive_permit_without_calls",
+                    1 if self.keepalive_permit_without_calls else 0,
+                )
+            )
+
+        if self.retry_policy is not None:
+            options.append(("grpc.enable_retries", 1))
+            options.append(("grpc.service_config", json.dumps(self.retry_policy.to_service_config())))
+
+        return options

--- a/durabletask/internal/shared.py
+++ b/durabletask/internal/shared.py
@@ -9,6 +9,7 @@ from typing import Any, Optional, Sequence, Union
 
 import grpc
 import grpc.aio
+from durabletask.grpc_options import GrpcChannelOptions
 
 ClientInterceptor = Union[
     grpc.UnaryUnaryClientInterceptor,
@@ -39,7 +40,8 @@ def get_default_host_address() -> str:
 def get_grpc_channel(
         host_address: Optional[str],
         secure_channel: bool = False,
-        interceptors: Optional[Sequence[ClientInterceptor]] = None) -> grpc.Channel:
+        interceptors: Optional[Sequence[ClientInterceptor]] = None,
+        channel_options: Optional[GrpcChannelOptions] = None) -> grpc.Channel:
 
     if host_address is None:
         host_address = get_default_host_address()
@@ -59,10 +61,21 @@ def get_grpc_channel(
             break
 
     # Create the base channel
+    options = channel_options.to_grpc_options() if channel_options is not None else None
     if secure_channel:
-        channel = grpc.secure_channel(host_address, grpc.ssl_channel_credentials())
+        if options is None:
+            channel = grpc.secure_channel(host_address, grpc.ssl_channel_credentials())
+        else:
+            channel = grpc.secure_channel(
+                host_address,
+                grpc.ssl_channel_credentials(),
+                options=options,
+            )
     else:
-        channel = grpc.insecure_channel(host_address)
+        if options is None:
+            channel = grpc.insecure_channel(host_address)
+        else:
+            channel = grpc.insecure_channel(host_address, options=options)
 
     # Apply interceptors ONLY if they exist
     if interceptors:
@@ -73,7 +86,8 @@ def get_grpc_channel(
 def get_async_grpc_channel(
         host_address: Optional[str],
         secure_channel: bool = False,
-        interceptors: Optional[Sequence[AsyncClientInterceptor]] = None) -> grpc.aio.Channel:
+        interceptors: Optional[Sequence[AsyncClientInterceptor]] = None,
+        channel_options: Optional[GrpcChannelOptions] = None) -> grpc.aio.Channel:
 
     if host_address is None:
         host_address = get_default_host_address()
@@ -90,14 +104,34 @@ def get_async_grpc_channel(
             host_address = host_address[len(protocol):]
             break
 
+    options = channel_options.to_grpc_options() if channel_options is not None else None
+
     if secure_channel:
-        channel = grpc.aio.secure_channel(
-            host_address, grpc.ssl_channel_credentials(),
-            interceptors=interceptors)
+        if options is None:
+            channel = grpc.aio.secure_channel(
+                host_address,
+                grpc.ssl_channel_credentials(),
+                interceptors=interceptors,
+            )
+        else:
+            channel = grpc.aio.secure_channel(
+                host_address,
+                grpc.ssl_channel_credentials(),
+                interceptors=interceptors,
+                options=options,
+            )
     else:
-        channel = grpc.aio.insecure_channel(
-            host_address,
-            interceptors=interceptors)
+        if options is None:
+            channel = grpc.aio.insecure_channel(
+                host_address,
+                interceptors=interceptors,
+            )
+        else:
+            channel = grpc.aio.insecure_channel(
+                host_address,
+                interceptors=interceptors,
+                options=options,
+            )
 
     return channel
 

--- a/durabletask/worker.py
+++ b/durabletask/worker.py
@@ -21,6 +21,7 @@ from packaging.version import InvalidVersion, parse
 import grpc
 from google.protobuf import empty_pb2
 
+from durabletask.grpc_options import GrpcChannelOptions
 from durabletask.entities.entity_operation_failed_exception import EntityOperationFailedException
 from durabletask.internal import helpers
 from durabletask.internal.entity_state_shim import StateShim
@@ -361,8 +362,13 @@ class TaskHubGrpcWorker:
             Defaults to None.
         secure_channel (bool, optional): Whether to use a secure gRPC channel (TLS).
             Defaults to False.
+        channel (Optional[grpc.Channel], optional): Pre-configured gRPC channel to use.
+            If set, host address, secure_channel, interceptors, and channel_options
+            are ignored when creating connections.
         interceptors (Optional[Sequence[shared.ClientInterceptor]], optional): Custom gRPC
             interceptors to apply to the channel. Defaults to None.
+        channel_options (Optional[GrpcChannelOptions], optional): Extra low-level gRPC
+            channel configuration including retry/service config options.
         concurrency_options (Optional[ConcurrencyOptions], optional): Configuration for
             controlling worker concurrency limits. If None, default settings are used.
 
@@ -426,8 +432,10 @@ class TaskHubGrpcWorker:
             metadata: Optional[list[tuple[str, str]]] = None,
             log_handler: Optional[logging.Handler] = None,
             log_formatter: Optional[logging.Formatter] = None,
+            channel: Optional[grpc.Channel] = None,
             secure_channel: bool = False,
             interceptors: Optional[Sequence[shared.ClientInterceptor]] = None,
+            channel_options: Optional[GrpcChannelOptions] = None,
             concurrency_options: Optional[ConcurrencyOptions] = None,
             maximum_timer_interval: Optional[timedelta] = DEFAULT_MAXIMUM_TIMER_INTERVAL,
             payload_store: Optional[PayloadStore] = None,
@@ -439,8 +447,10 @@ class TaskHubGrpcWorker:
         self._logger = shared.get_logger("worker", log_handler, log_formatter)
         self._shutdown = Event()
         self._is_running = False
+        self._channel = channel
         self._secure_channel = secure_channel
         self._payload_store = payload_store
+        self._channel_options = channel_options
 
         # Use provided concurrency options or create default ones
         self._concurrency_options = (
@@ -590,7 +600,7 @@ class TaskHubGrpcWorker:
 
         def create_fresh_connection():
             nonlocal current_channel, current_stub, conn_retry_count
-            if current_channel:
+            if current_channel and self._channel is None:
                 try:
                     current_channel.close()
                 except Exception:
@@ -598,16 +608,22 @@ class TaskHubGrpcWorker:
             current_channel = None
             current_stub = None
             try:
-                current_channel = shared.get_grpc_channel(
-                    self._host_address, self._secure_channel, self._interceptors
-                )
+                if self._channel is not None:
+                    current_channel = self._channel
+                else:
+                    current_channel = shared.get_grpc_channel(
+                        self._host_address,
+                        self._secure_channel,
+                        self._interceptors,
+                        channel_options=self._channel_options,
+                    )
                 current_stub = stubs.TaskHubSidecarServiceStub(current_channel)
                 current_stub.Hello(empty_pb2.Empty())
                 conn_retry_count = 0
                 self._logger.info(f"Created fresh connection to {self._host_address}")
             except Exception as e:
                 self._logger.warning(f"Failed to create connection: {e}")
-                current_channel = None
+                current_channel = self._channel if self._channel is not None else None
                 current_stub = None
                 raise
 
@@ -632,12 +648,12 @@ class TaskHubGrpcWorker:
                 current_reader_thread = None
 
             # Close the channel
-            if current_channel:
+            if current_channel and self._channel is None:
                 try:
                     current_channel.close()
                 except Exception:
                     pass
-            current_channel = None
+            current_channel = self._channel if self._channel is not None else None
             current_stub = None
 
         def should_invalidate_connection(rpc_error):

--- a/tests/durabletask-azuremanaged/test_durabletask_grpc_interceptor.py
+++ b/tests/durabletask-azuremanaged/test_durabletask_grpc_interceptor.py
@@ -3,11 +3,18 @@
 
 import unittest
 from concurrent import futures
+from datetime import datetime, timedelta, timezone
 from importlib.metadata import version
+import threading
+import time
 
 import grpc
+from azure.core.credentials import AccessToken
 
 from durabletask.azuremanaged.client import DurableTaskSchedulerClient
+from durabletask.azuremanaged.internal.access_token_manager import AccessTokenManager
+from durabletask.azuremanaged.worker import DurableTaskSchedulerWorker
+from durabletask.internal.grpc_interceptor import DefaultClientInterceptorImpl
 from durabletask.internal import orchestrator_service_pb2 as pb
 from durabletask.internal import orchestrator_service_pb2_grpc as stubs
 
@@ -52,6 +59,10 @@ class TestDurableTaskGrpcInterceptor(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.server.stop(grace=None)
+
+    def setUp(self):
+        self.mock_servicer.captured_metadata = {}
+        self.mock_servicer.requests_received = 0
 
     def test_user_agent_metadata_passed_in_request(self):
         """Test that the user agent metadata is correctly passed in gRPC requests."""
@@ -98,6 +109,67 @@ class TestDurableTaskGrpcInterceptor(unittest.TestCase):
             self.mock_servicer.captured_metadata["x-user-agent"],
             "gRPC user-agent should be different from our custom x-user-agent"
         )
+        self.assertNotIn("workerid", self.mock_servicer.captured_metadata)
+
+    def test_custom_interceptor_is_combined_with_dts_interceptor(self):
+        custom_interceptor = DefaultClientInterceptorImpl([("x-custom-header", "abc")])
+        task_hub_client = DurableTaskSchedulerClient(
+            host_address=self.server_address,
+            secure_channel=False,
+            taskhub="test-taskhub",
+            token_credential=None,
+            interceptors=[custom_interceptor],
+        )
+
+        task_hub_client.get_orchestration_state("test-instance-id")
+
+        self.assertEqual(1, self.mock_servicer.requests_received)
+        self.assertEqual("abc", self.mock_servicer.captured_metadata["x-custom-header"])
+        self.assertEqual("test-taskhub", self.mock_servicer.captured_metadata["taskhub"])
+
+    def test_worker_includes_workerid_header(self):
+        worker = DurableTaskSchedulerWorker(
+            host_address=self.server_address,
+            secure_channel=False,
+            taskhub="test-taskhub",
+            token_credential=None,
+        )
+
+        interceptor = worker._interceptors[-1]
+        metadata = dict(interceptor._metadata)
+        self.assertIn("workerid", metadata)
+        self.assertTrue(metadata["workerid"])
+
+
+class _TestTokenCredential:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.calls = 0
+
+    def get_token(self, _scope):
+        with self._lock:
+            self.calls += 1
+            call_number = self.calls
+        time.sleep(0.02)
+        return AccessToken(f"token-{call_number}", int(time.time()) + 3600)
+
+
+class TestAccessTokenManagerThreadSafety(unittest.TestCase):
+    def test_concurrent_refresh_performs_single_refresh(self):
+        credential = _TestTokenCredential()
+        manager = AccessTokenManager(credential)
+        manager.expiry_time = datetime.now(timezone.utc) - timedelta(seconds=1)
+
+        threads = []
+        for _ in range(8):
+            thread = threading.Thread(target=manager.get_access_token)
+            thread.start()
+            threads.append(thread)
+
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual(2, credential.calls)
 
 
 if __name__ == "__main__":

--- a/tests/durabletask/test_client.py
+++ b/tests/durabletask/test_client.py
@@ -1,16 +1,14 @@
 import json
 import pytest
-from unittest.mock import ANY, MagicMock, patch
-from google.protobuf import wrappers_pb2
-
-from durabletask.client import AsyncTaskHubGrpcClient, TaskHubGrpcClient
-from durabletask.grpc_options import GrpcChannelOptions, GrpcRetryPolicyOptions
 from datetime import datetime, timezone
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
+
+from google.protobuf import wrappers_pb2
 
 import durabletask.history as history
 import durabletask.internal.orchestrator_service_pb2 as pb
 from durabletask.client import AsyncTaskHubGrpcClient, OrchestrationStatus, TaskHubGrpcClient
+from durabletask.grpc_options import GrpcChannelOptions, GrpcRetryPolicyOptions
 from durabletask.payload.store import LargePayloadStorageOptions, PayloadStore
 
 from durabletask.internal.grpc_interceptor import (
@@ -290,6 +288,8 @@ def test_async_client_uses_provided_channel_directly():
         client = AsyncTaskHubGrpcClient(channel=provided_channel, host_address=HOST_ADDRESS)
         assert client._channel is provided_channel
         mock_get_channel.assert_not_called()
+
+
 def test_get_orchestration_history_aggregates_chunks_and_deexternalizes_payloads():
     store = FakePayloadStore()
     token = store.upload(b'history payload')

--- a/tests/durabletask/test_client.py
+++ b/tests/durabletask/test_client.py
@@ -1,6 +1,8 @@
+import json
 from unittest.mock import ANY, MagicMock, patch
 
-from durabletask.client import AsyncTaskHubGrpcClient
+from durabletask.client import AsyncTaskHubGrpcClient, TaskHubGrpcClient
+from durabletask.grpc_options import GrpcChannelOptions, GrpcRetryPolicyOptions
 
 from durabletask.internal.grpc_interceptor import (
     DefaultAsyncClientInterceptorImpl,
@@ -31,6 +33,33 @@ def test_get_grpc_channel_secure():
             'grpc.ssl_channel_credentials') as mock_credentials:
         get_grpc_channel(HOST_ADDRESS, True, interceptors=INTERCEPTORS)
         mock_channel.assert_called_once_with(HOST_ADDRESS, mock_credentials.return_value)
+
+
+def test_get_grpc_channel_with_channel_options():
+    options = GrpcChannelOptions(max_receive_message_length=1234)
+    with patch('grpc.insecure_channel') as mock_channel:
+        get_grpc_channel(HOST_ADDRESS, False, channel_options=options)
+        mock_channel.assert_called_once_with(
+            HOST_ADDRESS,
+            options=[('grpc.max_receive_message_length', 1234)],
+        )
+
+
+def test_get_grpc_channel_with_retry_policy_service_config():
+    retry = GrpcRetryPolicyOptions(max_attempts=5, retryable_status_codes=['UNAVAILABLE'])
+    options = GrpcChannelOptions(retry_policy=retry)
+    with patch('grpc.insecure_channel') as mock_channel:
+        get_grpc_channel(HOST_ADDRESS, False, channel_options=options)
+        _, kwargs = mock_channel.call_args
+        channel_options = kwargs['options']
+        assert ('grpc.enable_retries', 1) in channel_options
+        service_config_value = next(
+            option[1] for option in channel_options if option[0] == 'grpc.service_config'
+        )
+        service_config = json.loads(service_config_value)
+        retry_policy = service_config['methodConfig'][0]['retryPolicy']
+        assert retry_policy['maxAttempts'] == 5
+        assert retry_policy['retryableStatusCodes'] == ['UNAVAILABLE']
 
 
 def test_get_grpc_channel_default_host_address():
@@ -140,6 +169,17 @@ def test_get_async_grpc_channel_with_interceptors():
         mock_channel.assert_called_once_with(HOST_ADDRESS, interceptors=async_interceptors)
 
 
+def test_get_async_grpc_channel_with_channel_options():
+    options = GrpcChannelOptions(max_send_message_length=4321)
+    with patch('grpc.aio.insecure_channel') as mock_channel:
+        get_async_grpc_channel(HOST_ADDRESS, False, channel_options=options)
+        mock_channel.assert_called_once_with(
+            HOST_ADDRESS,
+            interceptors=None,
+            options=[('grpc.max_send_message_length', 4321)],
+        )
+
+
 def test_async_grpc_channel_protocol_stripping():
     with patch('grpc.aio.insecure_channel') as mock_insecure, patch(
             'grpc.aio.secure_channel') as mock_secure:
@@ -185,3 +225,19 @@ def test_async_client_creates_with_metadata():
         assert interceptors is not None
         assert len(interceptors) == 1
         assert isinstance(interceptors[0], DefaultAsyncClientInterceptorImpl)
+
+
+def test_client_uses_provided_channel_directly():
+    provided_channel = MagicMock()
+    with patch('durabletask.internal.shared.get_grpc_channel') as mock_get_channel:
+        client = TaskHubGrpcClient(channel=provided_channel, host_address=HOST_ADDRESS)
+        assert client._channel is provided_channel
+        mock_get_channel.assert_not_called()
+
+
+def test_async_client_uses_provided_channel_directly():
+    provided_channel = MagicMock()
+    with patch('durabletask.internal.shared.get_async_grpc_channel') as mock_get_channel:
+        client = AsyncTaskHubGrpcClient(channel=provided_channel, host_address=HOST_ADDRESS)
+        assert client._channel is provided_channel
+        mock_get_channel.assert_not_called()

--- a/tests/durabletask/test_client.py
+++ b/tests/durabletask/test_client.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 from unittest.mock import ANY, MagicMock, patch
 
 from durabletask.client import AsyncTaskHubGrpcClient, TaskHubGrpcClient
@@ -60,6 +61,15 @@ def test_get_grpc_channel_with_retry_policy_service_config():
         retry_policy = service_config['methodConfig'][0]['retryPolicy']
         assert retry_policy['maxAttempts'] == 5
         assert retry_policy['retryableStatusCodes'] == ['UNAVAILABLE']
+
+
+def test_retry_policy_format_duration_raises_on_zero():
+    with pytest.raises(ValueError, match="rounds to zero"):
+        GrpcRetryPolicyOptions(
+            max_attempts=2,
+            initial_backoff_seconds=1e-15,
+            max_backoff_seconds=1e-15,
+        )
 
 
 def test_get_grpc_channel_default_host_address():


### PR DESCRIPTION
## Summary

This PR closes the gRPC interceptor gaps identified by comparing the .NET SDK (`microsoft/durabletask-dotnet`) with the Python SDK. All changes are backward-compatible — every new parameter is optional with `None` defaults.

## Changes

### New: `GrpcChannelOptions` and `GrpcRetryPolicyOptions` (`durabletask/grpc_options.py`)

Two new public configuration dataclasses for transport-level gRPC customization:

- **`GrpcRetryPolicyOptions`** — configures gRPC service-config-based retries with `max_attempts`, exponential backoff parameters, and `retryable_status_codes`. Serializes directly to the gRPC service config JSON expected by `grpc.enable_retries` / `grpc.service_config` channel options.
- **`GrpcChannelOptions`** — wraps common channel settings (`max_receive_message_length`, `max_send_message_length`, keepalive, `retry_policy`, and an escape hatch `raw_options` list) and converts to the `list[tuple[str, Any]]` format accepted by gRPC channel constructors.

Both are exported from the top-level `durabletask` package.

### Core: channel creation and constructor updates

- `get_grpc_channel()` and `get_async_grpc_channel()` in `durabletask/internal/shared.py` now accept an optional `channel_options: GrpcChannelOptions` parameter, which is forwarded as `options=` to the underlying gRPC channel.
- `TaskHubGrpcClient`, `AsyncTaskHubGrpcClient`, and `TaskHubGrpcWorker` each gain two new optional parameters:
  - `channel` — a pre-configured `grpc.Channel` / `grpc.aio.Channel`. When provided, all channel-creation logic (including interceptors and channel options) is bypassed.
  - `channel_options` — a `GrpcChannelOptions` instance forwarded to the channel factory.
- The worker's internal `create_fresh_connection()` reconnect loop reuses the user-supplied channel instead of creating new ones, and skips attempting to close/destroy an externally-owned channel.

### Azure Managed: interceptor passthrough + workerid header + improved composition

- `DurableTaskSchedulerClient`, `AsyncDurableTaskSchedulerClient`, and `DurableTaskSchedulerWorker` now expose `interceptors`, `channel`, and `channel_options` parameters.
  - User-provided interceptors are **prepended**; the mandatory DTS auth/metadata interceptor is always **appended last**, ensuring `taskhub`, `x-user-agent`, and `authorization` headers are always present regardless of user customization.
- `DurableTaskSchedulerWorker` generates a `workerid` value (`hostname:pid:uuid4`) once per worker instance and injects it as a `"workerid"` gRPC metadata header on every call — matching the header added by the .NET SDK for service-side worker observability.
- `DTSDefaultClientInterceptorImpl.__init__` gains an optional `worker_id` parameter. Auth header mutation is consolidated into a shared `_upsert_authorization_header()` helper in both sync and async variants.

### Azure Managed: thread-safe token refresh

`AccessTokenManager.get_access_token()` (sync path) now uses a `threading.Lock` with double-checked locking. Under concurrent access, only one thread performs the refresh while others wait and reuse the result — eliminating redundant token acquisition calls.

## Tests

- `tests/durabletask/test_client.py`: 4 new tests — channel options forwarding to `grpc.insecure_channel`, retry service config JSON structure, async channel options, and both sync/async custom channel passthrough.
- `tests/durabletask-azuremanaged/test_durabletask_grpc_interceptor.py`: 3 new tests — custom user interceptor combined with DTS interceptors (real gRPC server), `workerid` header present on worker instances, and concurrent `AccessTokenManager` refresh performing a bounded number of credential calls.

## Gap mapping

| Gap | Description | Status |
|-----|-------------|--------|
| 1 | Missing `workerid` metadata on DTS worker | ✅ Fixed |
| 2 | No gRPC retry policy support | ✅ Fixed via `GrpcRetryPolicyOptions` + service config |
| 3 | No custom channel passthrough | ✅ Fixed via `channel` parameter |
| 4 | Azure Managed classes don't expose `interceptors` | ✅ Fixed |
| 5 | Sync token refresh race condition | ✅ Fixed with double-checked locking |
| 6 | No gRPC channel options customization | ✅ Fixed via `GrpcChannelOptions` |