### PR TITLE
Modernize typing to Python 3.10+ idioms

### DIFF
--- a/durabletask-azuremanaged/durabletask/azuremanaged/client.py
+++ b/durabletask-azuremanaged/durabletask/azuremanaged/client.py
@@ -2,8 +2,7 @@
 # Licensed under the MIT License.
 
 import logging
-
-from typing import Optional, Sequence
+from collections.abc import Sequence
 
 import grpc
 import grpc.aio
@@ -28,16 +27,16 @@ class DurableTaskSchedulerClient(TaskHubGrpcClient):
     def __init__(self, *,
                  host_address: str,
                  taskhub: str,
-                 token_credential: Optional[TokenCredential],
-                 channel: Optional[grpc.Channel] = None,
+                 token_credential: TokenCredential | None,
+                 channel: grpc.Channel | None = None,
                  secure_channel: bool = True,
-                 interceptors: Optional[Sequence[shared.ClientInterceptor]] = None,
-                 channel_options: Optional[GrpcChannelOptions] = None,
-                 resiliency_options: Optional[GrpcClientResiliencyOptions] = None,
-                 default_version: Optional[str] = None,
-                 payload_store: Optional[PayloadStore] = None,
-                 log_handler: Optional[logging.Handler] = None,
-                 log_formatter: Optional[logging.Formatter] = None):
+                 interceptors: Sequence[shared.ClientInterceptor] | None = None,
+                 channel_options: GrpcChannelOptions | None = None,
+                 resiliency_options: GrpcClientResiliencyOptions | None = None,
+                 default_version: str | None = None,
+                 payload_store: PayloadStore | None = None,
+                 log_handler: logging.Handler | None = None,
+                 log_formatter: logging.Formatter | None = None):
 
         if not taskhub:
             raise ValueError("Taskhub value cannot be empty. Please provide a value for your taskhub")
@@ -75,17 +74,17 @@ class AsyncDurableTaskSchedulerClient(AsyncTaskHubGrpcClient):
     Args:
         host_address (str): The gRPC endpoint address of the DTS service.
         taskhub (str): The name of the task hub. Cannot be empty.
-        token_credential (Optional[TokenCredential]): Azure credential for authentication.
+        token_credential (TokenCredential | None): Azure credential for authentication.
             If None, anonymous authentication will be used.
         secure_channel (bool, optional): Whether to use a secure gRPC channel (TLS).
             Defaults to True.
-        resiliency_options (Optional[GrpcClientResiliencyOptions], optional): Client-side
+        resiliency_options (GrpcClientResiliencyOptions | None, optional): Client-side
             gRPC resiliency settings forwarded to the base async client.
-        default_version (Optional[str], optional): Default version string for orchestrations.
-        payload_store (Optional[PayloadStore], optional): A payload store for
+        default_version (str | None, optional): Default version string for orchestrations.
+        payload_store (PayloadStore | None, optional): A payload store for
             externalizing large payloads. If None, payloads are sent inline.
-        log_handler (Optional[logging.Handler], optional): Custom logging handler for client logs.
-        log_formatter (Optional[logging.Formatter], optional): Custom log formatter for client logs.
+        log_handler (logging.Handler | None, optional): Custom logging handler for client logs.
+        log_formatter (logging.Formatter | None, optional): Custom log formatter for client logs.
 
     Raises:
         ValueError: If taskhub is empty or None.
@@ -106,16 +105,16 @@ class AsyncDurableTaskSchedulerClient(AsyncTaskHubGrpcClient):
     def __init__(self, *,
                  host_address: str,
                  taskhub: str,
-                 token_credential: Optional[AsyncTokenCredential],
-                 channel: Optional[grpc.aio.Channel] = None,
+                 token_credential: AsyncTokenCredential | None,
+                 channel: grpc.aio.Channel | None = None,
                  secure_channel: bool = True,
-                 interceptors: Optional[Sequence[shared.AsyncClientInterceptor]] = None,
-                 channel_options: Optional[GrpcChannelOptions] = None,
-                 resiliency_options: Optional[GrpcClientResiliencyOptions] = None,
-                 default_version: Optional[str] = None,
-                 payload_store: Optional[PayloadStore] = None,
-                 log_handler: Optional[logging.Handler] = None,
-                 log_formatter: Optional[logging.Formatter] = None):
+                 interceptors: Sequence[shared.AsyncClientInterceptor] | None = None,
+                 channel_options: GrpcChannelOptions | None = None,
+                 resiliency_options: GrpcClientResiliencyOptions | None = None,
+                 default_version: str | None = None,
+                 payload_store: PayloadStore | None = None,
+                 log_handler: logging.Handler | None = None,
+                 log_formatter: logging.Formatter | None = None):
 
         if not taskhub:
             raise ValueError("Taskhub value cannot be empty. Please provide a value for your taskhub")

--- a/durabletask-azuremanaged/durabletask/azuremanaged/internal/access_token_manager.py
+++ b/durabletask-azuremanaged/durabletask/azuremanaged/internal/access_token_manager.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 from datetime import datetime, timedelta, timezone
 from threading import Lock
-from typing import Optional
 
 from azure.core.credentials import AccessToken, TokenCredential
 from azure.core.credentials_async import AsyncTokenCredential
@@ -13,9 +12,9 @@ import durabletask.internal.shared as shared
 # By default, when there's 10minutes left before the token expires, refresh the token
 class AccessTokenManager:
 
-    _token: Optional[AccessToken]
+    _token: AccessToken | None
 
-    def __init__(self, token_credential: Optional[TokenCredential], refresh_interval_seconds: int = 600):
+    def __init__(self, token_credential: TokenCredential | None, refresh_interval_seconds: int = 600):
         self._scope = "https://durabletask.io/.default"
         self._refresh_interval_seconds = refresh_interval_seconds
         self._logger = shared.get_logger("token_manager")
@@ -30,7 +29,7 @@ class AccessTokenManager:
             self._token = None
             self.expiry_time = None
 
-    def get_access_token(self) -> Optional[AccessToken]:
+    def get_access_token(self) -> AccessToken | None:
         if self._token is None or self.is_token_expired():
             with self._refresh_lock:
                 if self._token is None or self.is_token_expired():
@@ -59,9 +58,9 @@ class AsyncAccessTokenManager:
 
     This avoids blocking the event loop when acquiring or refreshing tokens."""
 
-    _token: Optional[AccessToken]
+    _token: AccessToken | None
 
-    def __init__(self, token_credential: Optional[AsyncTokenCredential],
+    def __init__(self, token_credential: AsyncTokenCredential | None,
                  refresh_interval_seconds: int = 600):
         self._scope = "https://durabletask.io/.default"
         self._refresh_interval_seconds = refresh_interval_seconds
@@ -71,7 +70,7 @@ class AsyncAccessTokenManager:
         self._token = None
         self.expiry_time = None
 
-    async def get_access_token(self) -> Optional[AccessToken]:
+    async def get_access_token(self) -> AccessToken | None:
         if self._token is None or self.is_token_expired():
             await self.refresh_token()
         return self._token

--- a/durabletask-azuremanaged/durabletask/azuremanaged/internal/durabletask_grpc_interceptor.py
+++ b/durabletask-azuremanaged/durabletask/azuremanaged/internal/durabletask_grpc_interceptor.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 
 from importlib.metadata import version
-from typing import Optional
 
 import grpc
 from azure.core.credentials import TokenCredential
@@ -27,9 +26,9 @@ class DTSDefaultClientInterceptorImpl (DefaultClientInterceptorImpl):
 
     def __init__(
             self,
-            token_credential: Optional[TokenCredential],
+            token_credential: TokenCredential | None,
             taskhub_name: str,
-            worker_id: Optional[str] = None):
+            worker_id: str | None = None):
         try:
             # Get the version of the azuremanaged package
             sdk_version = version('durabletask-azuremanaged')
@@ -83,7 +82,7 @@ class DTSAsyncDefaultClientInterceptorImpl(DefaultAsyncClientInterceptorImpl):
     This class implements async gRPC interceptors to add DTS-specific headers
     (task hub name, user agent, and authentication token) to all async calls."""
 
-    def __init__(self, token_credential: Optional[AsyncTokenCredential], taskhub_name: str):
+    def __init__(self, token_credential: AsyncTokenCredential | None, taskhub_name: str):
         try:
             # Get the version of the azuremanaged package
             sdk_version = version('durabletask-azuremanaged')

--- a/durabletask-azuremanaged/durabletask/azuremanaged/worker.py
+++ b/durabletask-azuremanaged/durabletask/azuremanaged/worker.py
@@ -5,8 +5,7 @@ import logging
 import os
 import socket
 import uuid
-
-from typing import Optional, Sequence
+from collections.abc import Sequence
 
 import grpc
 from azure.core.credentials import TokenCredential
@@ -33,19 +32,19 @@ class DurableTaskSchedulerWorker(TaskHubGrpcWorker):
     Args:
         host_address (str): The gRPC endpoint address of the DTS service.
         taskhub (str): The name of the task hub. Cannot be empty.
-        token_credential (Optional[TokenCredential]): Azure credential for authentication.
+        token_credential (TokenCredential | None): Azure credential for authentication.
             If None, anonymous authentication will be used.
         secure_channel (bool, optional): Whether to use a secure gRPC channel (TLS).
             Defaults to True.
-        resiliency_options (Optional[GrpcWorkerResiliencyOptions], optional): Worker-side
+        resiliency_options (GrpcWorkerResiliencyOptions | None, optional): Worker-side
             gRPC resiliency settings forwarded to the base worker.
-        concurrency_options (Optional[ConcurrencyOptions], optional): Configuration
+        concurrency_options (ConcurrencyOptions | None, optional): Configuration
             for controlling worker concurrency limits. If None, default concurrency
             settings will be used.
-        payload_store (Optional[PayloadStore], optional): A payload store for
+        payload_store (PayloadStore | None, optional): A payload store for
             externalizing large payloads. If None, payloads are sent inline.
-        log_handler (Optional[logging.Handler], optional): Custom logging handler for worker logs.
-        log_formatter (Optional[logging.Formatter], optional): Custom log formatter for worker logs.
+        log_handler (logging.Handler | None, optional): Custom logging handler for worker logs.
+        log_formatter (logging.Formatter | None, optional): Custom log formatter for worker logs.
 
     Raises:
         ValueError: If taskhub is empty or None.
@@ -74,16 +73,16 @@ class DurableTaskSchedulerWorker(TaskHubGrpcWorker):
     def __init__(self, *,
                  host_address: str,
                  taskhub: str,
-                 token_credential: Optional[TokenCredential],
-                 channel: Optional[grpc.Channel] = None,
+                 token_credential: TokenCredential | None,
+                 channel: grpc.Channel | None = None,
                  secure_channel: bool = True,
-                 interceptors: Optional[Sequence[shared.ClientInterceptor]] = None,
-                 channel_options: Optional[GrpcChannelOptions] = None,
-                 resiliency_options: Optional[GrpcWorkerResiliencyOptions] = None,
-                 concurrency_options: Optional[ConcurrencyOptions] = None,
-                 payload_store: Optional[PayloadStore] = None,
-                 log_handler: Optional[logging.Handler] = None,
-                 log_formatter: Optional[logging.Formatter] = None):
+                 interceptors: Sequence[shared.ClientInterceptor] | None = None,
+                 channel_options: GrpcChannelOptions | None = None,
+                 resiliency_options: GrpcWorkerResiliencyOptions | None = None,
+                 concurrency_options: ConcurrencyOptions | None = None,
+                 payload_store: PayloadStore | None = None,
+                 log_handler: logging.Handler | None = None,
+                 log_formatter: logging.Formatter | None = None):
 
         if not taskhub:
             raise ValueError("The taskhub value cannot be empty.")

--- a/durabletask/client.py
+++ b/durabletask/client.py
@@ -9,7 +9,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, Generic, List, Optional, Sequence, TypeVar, Union
+from typing import Any, Generic, Sequence, TypeVar
 
 import grpc
 import grpc.aio
@@ -75,10 +75,10 @@ class OrchestrationState:
     runtime_status: OrchestrationStatus
     created_at: datetime
     last_updated_at: datetime
-    serialized_input: Optional[str]
-    serialized_output: Optional[str]
-    serialized_custom_status: Optional[str]
-    failure_details: Optional[task.FailureDetails]
+    serialized_input: str | None
+    serialized_output: str | None
+    serialized_custom_status: str | None
+    failure_details: task.FailureDetails | None
 
     def raise_if_failed(self):
         if self.failure_details is not None:
@@ -89,23 +89,23 @@ class OrchestrationState:
 
 @dataclass
 class OrchestrationQuery:
-    created_time_from: Optional[datetime] = None
-    created_time_to: Optional[datetime] = None
-    runtime_status: Optional[List[OrchestrationStatus]] = None
+    created_time_from: datetime | None = None
+    created_time_to: datetime | None = None
+    runtime_status: list[OrchestrationStatus] | None = None
     # Some backends don't respond well with max_instance_count = None, so we use the integer limit for non-paginated
     # results instead.
-    max_instance_count: Optional[int] = (1 << 31) - 1
+    max_instance_count: int | None = (1 << 31) - 1
     fetch_inputs_and_outputs: bool = False
 
 
 @dataclass
 class EntityQuery:
-    instance_id_starts_with: Optional[str] = None
-    last_modified_from: Optional[datetime] = None
-    last_modified_to: Optional[datetime] = None
+    instance_id_starts_with: str | None = None
+    last_modified_from: datetime | None = None
+    last_modified_to: datetime | None = None
     include_state: bool = True
     include_transient: bool = False
-    page_size: Optional[int] = None
+    page_size: int | None = None
 
 
 @dataclass
@@ -116,8 +116,8 @@ class PurgeInstancesResult:
 
 @dataclass
 class Page(Generic[TItem]):
-    items: List[TItem]
-    continuation_token: Optional[str]
+    items: list[TItem]
+    continuation_token: str | None
 
 
 @dataclass
@@ -136,7 +136,7 @@ class OrchestrationFailedError(Exception):
         return self._failure_details
 
 
-def new_orchestration_state(instance_id: str, res: pb.GetInstanceResponse) -> Optional[OrchestrationState]:
+def new_orchestration_state(instance_id: str, res: pb.GetInstanceResponse) -> OrchestrationState | None:
     if not res.exists:
         return None
 
@@ -175,17 +175,17 @@ _RETIRED_CHANNEL_CLOSE_DELAY_SECONDS = 30.0
 
 class TaskHubGrpcClient:
     def __init__(self, *,
-                 host_address: Optional[str] = None,
-                 metadata: Optional[list[tuple[str, str]]] = None,
-                 log_handler: Optional[logging.Handler] = None,
-                 log_formatter: Optional[logging.Formatter] = None,
-                 channel: Optional[grpc.Channel] = None,
+                 host_address: str | None = None,
+                 metadata: list[tuple[str, str]] | None = None,
+                 log_handler: logging.Handler | None = None,
+                 log_formatter: logging.Formatter | None = None,
+                 channel: grpc.Channel | None = None,
                  secure_channel: bool = False,
-                 interceptors: Optional[Sequence[shared.ClientInterceptor]] = None,
-                 channel_options: Optional[GrpcChannelOptions] = None,
-                 resiliency_options: Optional[GrpcClientResiliencyOptions] = None,
-                 default_version: Optional[str] = None,
-                 payload_store: Optional[PayloadStore] = None):
+                 interceptors: Sequence[shared.ClientInterceptor] | None = None,
+                 channel_options: GrpcChannelOptions | None = None,
+                 resiliency_options: GrpcClientResiliencyOptions | None = None,
+                 default_version: str | None = None,
+                 payload_store: PayloadStore | None = None):
 
         self._owns_channel = channel is None
         self._host_address = (
@@ -208,7 +208,7 @@ class TaskHubGrpcClient:
         self._recreate_lock = threading.Lock()
         self._retired_channels: dict[grpc.Channel, threading.Timer] = {}
         self._recreate_thread_lock = threading.Lock()
-        self._recreate_thread: Optional[threading.Thread] = None
+        self._recreate_thread: threading.Thread | None = None
         # Test seam: set after each fire-and-forget recreate attempt finishes
         # (whether it actually recreated the channel or short-circuited on
         # close / cooldown). Lets tests synchronise without polling and lets
@@ -252,14 +252,14 @@ class TaskHubGrpcClient:
 
     def _compose_interceptors(
             self,
-            user_interceptors: Optional[List[shared.ClientInterceptor]],
-    ) -> List[shared.ClientInterceptor]:
+            user_interceptors: list[shared.ClientInterceptor] | None,
+    ) -> list[shared.ClientInterceptor]:
         """Prepend the resiliency interceptor so user interceptors run after it.
 
         The resiliency interceptor wraps the underlying continuation, so it
         observes every unary call regardless of any user-supplied interceptors.
         """
-        composed: List[shared.ClientInterceptor] = [self._resiliency_interceptor]
+        composed: list[shared.ClientInterceptor] = [self._resiliency_interceptor]
         if user_interceptors:
             composed.extend(user_interceptors)
         return composed
@@ -366,13 +366,13 @@ class TaskHubGrpcClient:
                 retired_channel.close()
             current_channel.close()
 
-    def schedule_new_orchestration(self, orchestrator: Union[task.Orchestrator[TInput, TOutput], str], *,
-                                   input: Optional[TInput] = None,
-                                   instance_id: Optional[str] = None,
-                                   start_at: Optional[datetime] = None,
-                                   reuse_id_policy: Optional[pb.OrchestrationIdReusePolicy] = None,
-                                   tags: Optional[dict[str, str]] = None,
-                                   version: Optional[str] = None) -> str:
+    def schedule_new_orchestration(self, orchestrator: task.Orchestrator[TInput, TOutput] | str, *,
+                                   input: TInput | None = None,
+                                   instance_id: str | None = None,
+                                   start_at: datetime | None = None,
+                                   reuse_id_policy: pb.OrchestrationIdReusePolicy | None = None,
+                                   tags: dict[str, str] | None = None,
+                                   version: str | None = None) -> str:
 
         name = orchestrator if isinstance(orchestrator, str) else task.get_name(orchestrator)
         resolved_instance_id = instance_id if instance_id else uuid.uuid4().hex
@@ -402,7 +402,7 @@ class TaskHubGrpcClient:
             res: pb.CreateInstanceResponse = self._stub.StartInstance(req)
             return res.instanceId
 
-    def get_orchestration_state(self, instance_id: str, *, fetch_payloads: bool = True) -> Optional[OrchestrationState]:
+    def get_orchestration_state(self, instance_id: str, *, fetch_payloads: bool = True) -> OrchestrationState | None:
         req = pb.GetInstanceRequest(instanceId=instance_id, getInputsAndOutputs=fetch_payloads)
         res: pb.GetInstanceResponse = self._stub.GetInstance(req)
         # De-externalize any large-payload tokens in the response
@@ -412,8 +412,8 @@ class TaskHubGrpcClient:
 
     def get_orchestration_history(self,
                                   instance_id: str, *,
-                                  execution_id: Optional[str] = None,
-                                  for_work_item_processing: bool = False) -> List[history.HistoryEvent]:
+                                  execution_id: str | None = None,
+                                  for_work_item_processing: bool = False) -> list[history.HistoryEvent]:
         req = pb.StreamInstanceHistoryRequest(
             instanceId=instance_id,
             executionId=helpers.get_string_value(execution_id),
@@ -424,11 +424,11 @@ class TaskHubGrpcClient:
         return history_helpers.collect_history_events(stream, self._payload_store)
 
     def list_instance_ids(self,
-                          runtime_status: Optional[List[OrchestrationStatus]] = None,
-                          completed_time_from: Optional[datetime] = None,
-                          completed_time_to: Optional[datetime] = None,
-                          page_size: Optional[int] = None,
-                          continuation_token: Optional[str] = None) -> Page[str]:
+                          runtime_status: list[OrchestrationStatus] | None = None,
+                          completed_time_from: datetime | None = None,
+                          completed_time_to: datetime | None = None,
+                          page_size: int | None = None,
+                          continuation_token: str | None = None) -> Page[str]:
         req = pb.ListInstanceIdsRequest(
             runtimeStatus=[status.value for status in runtime_status] if runtime_status else [],
             completedTimeFrom=helpers.new_timestamp(completed_time_from) if completed_time_from else None,
@@ -449,8 +449,8 @@ class TaskHubGrpcClient:
         return Page(items=list(resp.instanceIds), continuation_token=next_token)
 
     def get_all_orchestration_states(self,
-                                     orchestration_query: Optional[OrchestrationQuery] = None
-                                     ) -> List[OrchestrationState]:
+                                     orchestration_query: OrchestrationQuery | None = None
+                                     ) -> list[OrchestrationState]:
         if orchestration_query is None:
             orchestration_query = OrchestrationQuery()
         _continuation_token = None
@@ -474,7 +474,7 @@ class TaskHubGrpcClient:
 
     def wait_for_orchestration_start(self, instance_id: str, *,
                                      fetch_payloads: bool = False,
-                                     timeout: float = 60) -> Optional[OrchestrationState]:
+                                     timeout: float = 60) -> OrchestrationState | None:
         req = pb.GetInstanceRequest(instanceId=instance_id, getInputsAndOutputs=fetch_payloads)
         try:
             self._logger.info(f"Waiting up to {timeout}s for instance '{instance_id}' to start.")
@@ -494,7 +494,7 @@ class TaskHubGrpcClient:
 
     def wait_for_orchestration_completion(self, instance_id: str, *,
                                           fetch_payloads: bool = True,
-                                          timeout: float = 60) -> Optional[OrchestrationState]:
+                                          timeout: float = 60) -> OrchestrationState | None:
         req = pb.GetInstanceRequest(instanceId=instance_id, getInputsAndOutputs=fetch_payloads)
         try:
             self._logger.info(f"Waiting {timeout}s for instance '{instance_id}' to complete.")
@@ -514,7 +514,7 @@ class TaskHubGrpcClient:
                 raise
 
     def raise_orchestration_event(self, instance_id: str, event_name: str, *,
-                                  data: Optional[Any] = None) -> None:
+                                  data: Any | None = None) -> None:
         with tracing.start_raise_event_span(event_name, instance_id):
             req = build_raise_event_req(instance_id, event_name, data)
             self._logger.info(f"Raising event '{event_name}' for instance '{instance_id}'.")
@@ -525,7 +525,7 @@ class TaskHubGrpcClient:
             self._stub.RaiseEvent(req)
 
     def terminate_orchestration(self, instance_id: str, *,
-                                output: Optional[Any] = None,
+                                output: Any | None = None,
                                 recursive: bool = True) -> None:
         req = build_terminate_req(instance_id, output, recursive)
 
@@ -573,9 +573,9 @@ class TaskHubGrpcClient:
         return PurgeInstancesResult(resp.deletedInstanceCount, resp.isComplete.value)
 
     def purge_orchestrations_by(self,
-                                created_time_from: Optional[datetime] = None,
-                                created_time_to: Optional[datetime] = None,
-                                runtime_status: Optional[List[OrchestrationStatus]] = None,
+                                created_time_from: datetime | None = None,
+                                created_time_to: datetime | None = None,
+                                runtime_status: list[OrchestrationStatus] | None = None,
                                 recursive: bool = False) -> PurgeInstancesResult:
         self._logger.info("Purging orchestrations by filter: "
                           f"created_time_from={created_time_from}, "
@@ -589,7 +589,7 @@ class TaskHubGrpcClient:
     def signal_entity(self,
                       entity_instance_id: EntityInstanceId,
                       operation_name: str,
-                      input: Optional[Any] = None) -> None:
+                      input: Any | None = None) -> None:
         req = build_signal_entity_req(entity_instance_id, operation_name, input)
         self._logger.info(f"Signaling entity '{entity_instance_id}' operation '{operation_name}'.")
         if self._payload_store is not None:
@@ -601,7 +601,7 @@ class TaskHubGrpcClient:
     def get_entity(self,
                    entity_instance_id: EntityInstanceId,
                    include_state: bool = True
-                   ) -> Optional[EntityMetadata]:
+                   ) -> EntityMetadata | None:
         req = pb.GetEntityRequest(instanceId=str(entity_instance_id), includeState=include_state)
         self._logger.info(f"Getting entity '{entity_instance_id}'.")
         res: pb.GetEntityResponse = self._stub.GetEntity(req)
@@ -612,7 +612,7 @@ class TaskHubGrpcClient:
         return EntityMetadata.from_entity_metadata(res.entity, include_state)
 
     def get_all_entities(self,
-                         entity_query: Optional[EntityQuery] = None) -> List[EntityMetadata]:
+                         entity_query: EntityQuery | None = None) -> list[EntityMetadata]:
         if entity_query is None:
             entity_query = EntityQuery()
         _continuation_token = None
@@ -665,17 +665,17 @@ class AsyncTaskHubGrpcClient:
     """Async version of TaskHubGrpcClient using grpc.aio for asyncio-based applications."""
 
     def __init__(self, *,
-                 host_address: Optional[str] = None,
-                 metadata: Optional[list[tuple[str, str]]] = None,
-                 log_handler: Optional[logging.Handler] = None,
-                 log_formatter: Optional[logging.Formatter] = None,
-                 channel: Optional[grpc.aio.Channel] = None,
+                 host_address: str | None = None,
+                 metadata: list[tuple[str, str]] | None = None,
+                 log_handler: logging.Handler | None = None,
+                 log_formatter: logging.Formatter | None = None,
+                 channel: grpc.aio.Channel | None = None,
                  secure_channel: bool = False,
-                 interceptors: Optional[Sequence[shared.AsyncClientInterceptor]] = None,
-                 channel_options: Optional[GrpcChannelOptions] = None,
-                 resiliency_options: Optional[GrpcClientResiliencyOptions] = None,
-                 default_version: Optional[str] = None,
-                 payload_store: Optional[PayloadStore] = None):
+                 interceptors: Sequence[shared.AsyncClientInterceptor] | None = None,
+                 channel_options: GrpcChannelOptions | None = None,
+                 resiliency_options: GrpcClientResiliencyOptions | None = None,
+                 default_version: str | None = None,
+                 payload_store: PayloadStore | None = None):
 
         self._owns_channel = channel is None
         self._host_address = (
@@ -698,7 +698,7 @@ class AsyncTaskHubGrpcClient:
         self._last_recreate_time = 0.0
         self._retired_channels: list[grpc.aio.Channel] = []
         self._retired_channel_close_tasks: set[asyncio.Task[None]] = set()
-        self._recreate_task: Optional[asyncio.Task[None]] = None
+        self._recreate_task: asyncio.Task[None] | None = None
         # Test seam: set after each fire-and-forget recreate attempt finishes
         # (whether it actually recreated the channel or short-circuited on
         # close / cooldown). Lets tests synchronise without polling and lets
@@ -742,10 +742,10 @@ class AsyncTaskHubGrpcClient:
 
     def _compose_interceptors(
             self,
-            user_interceptors: Optional[List[shared.AsyncClientInterceptor]],
-    ) -> List[shared.AsyncClientInterceptor]:
+            user_interceptors: list[shared.AsyncClientInterceptor] | None,
+    ) -> list[shared.AsyncClientInterceptor]:
         """Prepend the resiliency interceptor so user interceptors run after it."""
-        composed: List[shared.AsyncClientInterceptor] = [self._resiliency_interceptor]
+        composed: list[shared.AsyncClientInterceptor] = [self._resiliency_interceptor]
         if user_interceptors:
             composed.extend(user_interceptors)
         return composed
@@ -850,13 +850,13 @@ class AsyncTaskHubGrpcClient:
                 if channel in self._retired_channels:
                     self._retired_channels.remove(channel)
 
-    async def schedule_new_orchestration(self, orchestrator: Union[task.Orchestrator[TInput, TOutput], str], *,
-                                         input: Optional[TInput] = None,
-                                         instance_id: Optional[str] = None,
-                                         start_at: Optional[datetime] = None,
-                                         reuse_id_policy: Optional[pb.OrchestrationIdReusePolicy] = None,
-                                         tags: Optional[dict[str, str]] = None,
-                                         version: Optional[str] = None) -> str:
+    async def schedule_new_orchestration(self, orchestrator: task.Orchestrator[TInput, TOutput] | str, *,
+                                         input: TInput | None = None,
+                                         instance_id: str | None = None,
+                                         start_at: datetime | None = None,
+                                         reuse_id_policy: pb.OrchestrationIdReusePolicy | None = None,
+                                         tags: dict[str, str] | None = None,
+                                         version: str | None = None) -> str:
 
         name = orchestrator if isinstance(orchestrator, str) else task.get_name(orchestrator)
         resolved_instance_id = instance_id if instance_id else uuid.uuid4().hex
@@ -884,7 +884,7 @@ class AsyncTaskHubGrpcClient:
             return res.instanceId
 
     async def get_orchestration_state(self, instance_id: str, *,
-                                      fetch_payloads: bool = True) -> Optional[OrchestrationState]:
+                                      fetch_payloads: bool = True) -> OrchestrationState | None:
         req = pb.GetInstanceRequest(instanceId=instance_id, getInputsAndOutputs=fetch_payloads)
         res: pb.GetInstanceResponse = await self._stub.GetInstance(req)
         if self._payload_store is not None and res.exists:
@@ -893,8 +893,8 @@ class AsyncTaskHubGrpcClient:
 
     async def get_orchestration_history(self,
                                         instance_id: str, *,
-                                        execution_id: Optional[str] = None,
-                                        for_work_item_processing: bool = False) -> List[history.HistoryEvent]:
+                                        execution_id: str | None = None,
+                                        for_work_item_processing: bool = False) -> list[history.HistoryEvent]:
         req = pb.StreamInstanceHistoryRequest(
             instanceId=instance_id,
             executionId=helpers.get_string_value(execution_id),
@@ -905,11 +905,11 @@ class AsyncTaskHubGrpcClient:
         return await history_helpers.collect_history_events_async(stream, self._payload_store)
 
     async def list_instance_ids(self,
-                                runtime_status: Optional[List[OrchestrationStatus]] = None,
-                                completed_time_from: Optional[datetime] = None,
-                                completed_time_to: Optional[datetime] = None,
-                                page_size: Optional[int] = None,
-                                continuation_token: Optional[str] = None) -> Page[str]:
+                                runtime_status: list[OrchestrationStatus] | None = None,
+                                completed_time_from: datetime | None = None,
+                                completed_time_to: datetime | None = None,
+                                page_size: int | None = None,
+                                continuation_token: str | None = None) -> Page[str]:
         req = pb.ListInstanceIdsRequest(
             runtimeStatus=[status.value for status in runtime_status] if runtime_status else [],
             completedTimeFrom=helpers.new_timestamp(completed_time_from) if completed_time_from else None,
@@ -930,8 +930,8 @@ class AsyncTaskHubGrpcClient:
         return Page(items=list(resp.instanceIds), continuation_token=next_token)
 
     async def get_all_orchestration_states(self,
-                                           orchestration_query: Optional[OrchestrationQuery] = None
-                                           ) -> List[OrchestrationState]:
+                                           orchestration_query: OrchestrationQuery | None = None
+                                           ) -> list[OrchestrationState]:
         if orchestration_query is None:
             orchestration_query = OrchestrationQuery()
         _continuation_token = None
@@ -955,7 +955,7 @@ class AsyncTaskHubGrpcClient:
 
     async def wait_for_orchestration_start(self, instance_id: str, *,
                                            fetch_payloads: bool = False,
-                                           timeout: float = 60) -> Optional[OrchestrationState]:
+                                           timeout: float = 60) -> OrchestrationState | None:
         req = pb.GetInstanceRequest(instanceId=instance_id, getInputsAndOutputs=fetch_payloads)
         try:
             self._logger.info(f"Waiting up to {timeout}s for instance '{instance_id}' to start.")
@@ -974,7 +974,7 @@ class AsyncTaskHubGrpcClient:
 
     async def wait_for_orchestration_completion(self, instance_id: str, *,
                                                 fetch_payloads: bool = True,
-                                                timeout: float = 60) -> Optional[OrchestrationState]:
+                                                timeout: float = 60) -> OrchestrationState | None:
         req = pb.GetInstanceRequest(instanceId=instance_id, getInputsAndOutputs=fetch_payloads)
         try:
             self._logger.info(f"Waiting {timeout}s for instance '{instance_id}' to complete.")
@@ -994,7 +994,7 @@ class AsyncTaskHubGrpcClient:
                 raise
 
     async def raise_orchestration_event(self, instance_id: str, event_name: str, *,
-                                        data: Optional[Any] = None) -> None:
+                                        data: Any | None = None) -> None:
         with tracing.start_raise_event_span(event_name, instance_id):
             req = build_raise_event_req(instance_id, event_name, data)
             self._logger.info(f"Raising event '{event_name}' for instance '{instance_id}'.")
@@ -1005,7 +1005,7 @@ class AsyncTaskHubGrpcClient:
             await self._stub.RaiseEvent(req)
 
     async def terminate_orchestration(self, instance_id: str, *,
-                                      output: Optional[Any] = None,
+                                      output: Any | None = None,
                                       recursive: bool = True) -> None:
         req = build_terminate_req(instance_id, output, recursive)
 
@@ -1053,9 +1053,9 @@ class AsyncTaskHubGrpcClient:
         return PurgeInstancesResult(resp.deletedInstanceCount, resp.isComplete.value)
 
     async def purge_orchestrations_by(self,
-                                      created_time_from: Optional[datetime] = None,
-                                      created_time_to: Optional[datetime] = None,
-                                      runtime_status: Optional[List[OrchestrationStatus]] = None,
+                                      created_time_from: datetime | None = None,
+                                      created_time_to: datetime | None = None,
+                                      runtime_status: list[OrchestrationStatus] | None = None,
                                       recursive: bool = False) -> PurgeInstancesResult:
         self._logger.info("Purging orchestrations by filter: "
                           f"created_time_from={created_time_from}, "
@@ -1069,7 +1069,7 @@ class AsyncTaskHubGrpcClient:
     async def signal_entity(self,
                             entity_instance_id: EntityInstanceId,
                             operation_name: str,
-                            input: Optional[Any] = None) -> None:
+                            input: Any | None = None) -> None:
         req = build_signal_entity_req(entity_instance_id, operation_name, input)
         self._logger.info(f"Signaling entity '{entity_instance_id}' operation '{operation_name}'.")
         if self._payload_store is not None:
@@ -1081,7 +1081,7 @@ class AsyncTaskHubGrpcClient:
     async def get_entity(self,
                          entity_instance_id: EntityInstanceId,
                          include_state: bool = True
-                         ) -> Optional[EntityMetadata]:
+                         ) -> EntityMetadata | None:
         req = pb.GetEntityRequest(instanceId=str(entity_instance_id), includeState=include_state)
         self._logger.info(f"Getting entity '{entity_instance_id}'.")
         res: pb.GetEntityResponse = await self._stub.GetEntity(req)
@@ -1092,7 +1092,7 @@ class AsyncTaskHubGrpcClient:
         return EntityMetadata.from_entity_metadata(res.entity, include_state)
 
     async def get_all_entities(self,
-                               entity_query: Optional[EntityQuery] = None) -> List[EntityMetadata]:
+                               entity_query: EntityQuery | None = None) -> list[EntityMetadata]:
         if entity_query is None:
             entity_query = EntityQuery()
         _continuation_token = None

--- a/durabletask/entities/durable_entity.py
+++ b/durabletask/entities/durable_entity.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Type, TypeVar, Union, overload
+from typing import Any, TypeVar, overload
 
 from durabletask.entities.entity_context import EntityContext
 from durabletask.entities.entity_instance_id import EntityInstanceId
@@ -11,23 +11,23 @@ class DurableEntity:
         self.entity_context = context
 
     @overload
-    def get_state(self, intended_type: Type[TState], default: TState) -> TState:
+    def get_state(self, intended_type: type[TState], default: TState) -> TState:
         ...
 
     @overload
-    def get_state(self, intended_type: Type[TState]) -> Optional[TState]:
+    def get_state(self, intended_type: type[TState]) -> TState | None:
         ...
 
     @overload
     def get_state(self, intended_type: None = None, default: Any = None) -> Any:
         ...
 
-    def get_state(self, intended_type: Optional[Type[TState]] = None, default: Optional[TState] = None) -> Union[None, TState, Any]:
+    def get_state(self, intended_type: type[TState] | None = None, default: TState | None = None) -> TState | Any | None:
         """Get the current state of the entity, optionally converting it to a specified type.
 
         Parameters
         ----------
-        intended_type : Type[TState] | None, optional
+        intended_type : type[TState] | None, optional
             The type to which the state should be converted. If None, the state is returned as-is.
         default : TState, optional
             The default value to return if the state is not found or cannot be converted.
@@ -49,7 +49,7 @@ class DurableEntity:
         """
         self.entity_context.set_state(state)
 
-    def signal_entity(self, entity_instance_id: EntityInstanceId, operation: str, input: Optional[Any] = None) -> None:
+    def signal_entity(self, entity_instance_id: EntityInstanceId, operation: str, input: Any | None = None) -> None:
         """Signal another entity to perform an operation.
 
         Parameters
@@ -63,7 +63,7 @@ class DurableEntity:
         """
         self.entity_context.signal_entity(entity_instance_id, operation, input)
 
-    def schedule_new_orchestration(self, orchestration_name: str, input: Optional[Any] = None, instance_id: Optional[str] = None) -> str:
+    def schedule_new_orchestration(self, orchestration_name: str, input: Any | None = None, instance_id: str | None = None) -> str:
         """Schedule a new orchestration instance.
 
         Parameters

--- a/durabletask/entities/entity_context.py
+++ b/durabletask/entities/entity_context.py
@@ -1,5 +1,5 @@
 
-from typing import Any, Optional, Type, TypeVar, Union, overload
+from typing import Any, TypeVar, overload
 import uuid
 from durabletask.entities.entity_instance_id import EntityInstanceId
 from durabletask.internal import helpers, shared
@@ -43,23 +43,23 @@ class EntityContext:
         return self._operation
 
     @overload
-    def get_state(self, intended_type: Type[TState], default: TState) -> TState:
+    def get_state(self, intended_type: type[TState], default: TState) -> TState:
         ...
 
     @overload
-    def get_state(self, intended_type: Type[TState]) -> Optional[TState]:
+    def get_state(self, intended_type: type[TState]) -> TState | None:
         ...
 
     @overload
     def get_state(self, intended_type: None = None, default: Any = None) -> Any:
         ...
 
-    def get_state(self, intended_type: Optional[Type[TState]] = None, default: Optional[TState] = None) -> Union[None, TState, Any]:
+    def get_state(self, intended_type: type[TState] | None = None, default: TState | None = None) -> TState | Any | None:
         """Get the current state of the entity, optionally converting it to a specified type.
 
         Parameters
         ----------
-        intended_type : Type[TState] | None, optional
+        intended_type : type[TState] | None, optional
             The type to which the state should be converted. If None, the state is returned as-is.
         default : TState, optional
             The default value to return if the state is not found or cannot be converted.
@@ -81,7 +81,7 @@ class EntityContext:
         """
         self._state.set_state(new_state)
 
-    def signal_entity(self, entity_instance_id: EntityInstanceId, operation: str, input: Optional[Any] = None) -> None:
+    def signal_entity(self, entity_instance_id: EntityInstanceId, operation: str, input: Any | None = None) -> None:
         """Signal another entity to perform an operation.
 
         Parameters
@@ -107,7 +107,7 @@ class EntityContext:
             )
         )
 
-    def schedule_new_orchestration(self, orchestration_name: str, input: Optional[Any] = None, instance_id: Optional[str] = None) -> str:
+    def schedule_new_orchestration(self, orchestration_name: str, input: Any | None = None, instance_id: str | None = None) -> str:
         """Schedule a new orchestration instance.
 
         Parameters

--- a/durabletask/entities/entity_lock.py
+++ b/durabletask/entities/entity_lock.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 
@@ -7,7 +9,7 @@ if TYPE_CHECKING:
 
 class EntityLock:
     # Note: This should
-    def __init__(self, context: 'OrchestrationContext'):
+    def __init__(self, context: OrchestrationContext):
         self._context = context
 
     def __enter__(self):

--- a/durabletask/entities/entity_metadata.py
+++ b/durabletask/entities/entity_metadata.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Any, Optional, Type, TypeVar, Union, overload
+from typing import Any, TypeVar, overload
 from durabletask.entities.entity_instance_id import EntityInstanceId
 
 import durabletask.internal.orchestrator_service_pb2 as pb
@@ -20,7 +20,7 @@ class EntityMetadata:
         backlog_queue_size (int): The size of the backlog queue for the entity.
         locked_by (str): The identifier of the worker that currently holds the lock on the entity.
         includes_state (bool): Indicates whether the metadata includes the state of the entity.
-        state (Optional[Any]): The current state of the entity, if included.
+        state (Any | None): The current state of the entity, if included.
     """
 
     def __init__(self,
@@ -29,7 +29,7 @@ class EntityMetadata:
                  backlog_queue_size: int,
                  locked_by: str,
                  includes_state: bool,
-                 state: Optional[Any]):
+                 state: Any | None):
         """Initializes a new instance of the EntityMetadata class.
 
         Args:
@@ -65,14 +65,14 @@ class EntityMetadata:
         )
 
     @overload
-    def get_state(self, intended_type: Type[TState]) -> Optional[TState]:
+    def get_state(self, intended_type: type[TState]) -> TState | None:
         ...
 
     @overload
     def get_state(self, intended_type: None = None) -> Any:
         ...
 
-    def get_state(self, intended_type: Optional[Type[TState]] = None) -> Union[None, TState, Any]:
+    def get_state(self, intended_type: type[TState] | None = None) -> TState | Any | None:
         """Get the current state of the entity, optionally converting it to a specified type."""
         if intended_type is None or self._state is None:
             return self._state
@@ -87,7 +87,7 @@ class EntityMetadata:
                 f"Could not convert state of type '{type(self._state).__name__}' to '{intended_type.__name__}'"
             ) from ex
 
-    def get_locked_by(self) -> Optional[EntityInstanceId]:
+    def get_locked_by(self) -> EntityInstanceId | None:
         """Get the identifier of the worker that currently holds the lock on the entity.
 
         Returns

--- a/durabletask/extensions/azure_blob_payloads/blob_payload_store.py
+++ b/durabletask/extensions/azure_blob_payloads/blob_payload_store.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import gzip
 import logging
 import uuid
-from typing import Optional
 
 from azure.core.exceptions import ResourceExistsError
 from azure.storage.blob import BlobServiceClient
@@ -115,7 +114,7 @@ class BlobPayloadStore(PayloadStore):
     # Sync operations
     # ------------------------------------------------------------------
 
-    def upload(self, data: bytes, *, instance_id: Optional[str] = None) -> str:
+    def upload(self, data: bytes, *, instance_id: str | None = None) -> str:
         self._ensure_container_sync()
 
         if self._options.enable_compression:
@@ -144,7 +143,7 @@ class BlobPayloadStore(PayloadStore):
     # Async operations
     # ------------------------------------------------------------------
 
-    async def upload_async(self, data: bytes, *, instance_id: Optional[str] = None) -> str:
+    async def upload_async(self, data: bytes, *, instance_id: str | None = None) -> str:
         await self._ensure_container_async()
 
         if self._options.enable_compression:
@@ -193,7 +192,7 @@ class BlobPayloadStore(PayloadStore):
         return parts[0], parts[1]
 
     @staticmethod
-    def _make_blob_name(instance_id: Optional[str] = None) -> str:
+    def _make_blob_name(instance_id: str | None = None) -> str:
         """Generate a blob name, optionally scoped under an instance ID folder."""
         unique = uuid.uuid4().hex
         if instance_id:

--- a/durabletask/extensions/azure_blob_payloads/options.py
+++ b/durabletask/extensions/azure_blob_payloads/options.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 from durabletask.payload.store import LargePayloadStorageOptions
 
@@ -34,7 +34,7 @@ class BlobPayloadStoreOptions(LargePayloadStorageOptions):
             Azurite compatibility).
     """
     container_name: str = "durabletask-payloads"
-    connection_string: Optional[str] = None
-    account_url: Optional[str] = None
+    connection_string: str | None = None
+    account_url: str | None = None
     credential: Any = field(default=None, repr=False)
-    api_version: Optional[str] = None
+    api_version: str | None = None

--- a/durabletask/history.py
+++ b/durabletask/history.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any
 
 from google.protobuf import json_format
 from google.protobuf.message import Message
@@ -17,22 +17,22 @@ import durabletask.internal.orchestrator_service_pb2 as pb
 @dataclass(slots=True)
 class OrchestrationInstance:
     instance_id: str
-    execution_id: Optional[str] = None
+    execution_id: str | None = None
 
 
 @dataclass(slots=True)
 class ParentInstanceInfo:
     task_scheduled_id: int
-    name: Optional[str] = None
-    version: Optional[str] = None
-    orchestration_instance: Optional[OrchestrationInstance] = None
+    name: str | None = None
+    version: str | None = None
+    orchestration_instance: OrchestrationInstance | None = None
 
 
 @dataclass(slots=True)
 class TraceContext:
     trace_parent: str
     span_id: str
-    trace_state: Optional[str] = None
+    trace_state: str | None = None
 
 
 @dataclass(slots=True)
@@ -47,70 +47,70 @@ class HistoryEvent:
 @dataclass(slots=True)
 class ExecutionStartedEvent(HistoryEvent):
     name: str
-    version: Optional[str] = None
-    input: Optional[str] = None
-    orchestration_instance: Optional[OrchestrationInstance] = None
-    parent_instance: Optional[ParentInstanceInfo] = None
-    scheduled_start_timestamp: Optional[datetime] = None
-    parent_trace_context: Optional[TraceContext] = None
-    orchestration_span_id: Optional[str] = None
-    tags: Optional[dict[str, str]] = None
+    version: str | None = None
+    input: str | None = None
+    orchestration_instance: OrchestrationInstance | None = None
+    parent_instance: ParentInstanceInfo | None = None
+    scheduled_start_timestamp: datetime | None = None
+    parent_trace_context: TraceContext | None = None
+    orchestration_span_id: str | None = None
+    tags: dict[str, str] | None = None
 
 
 @dataclass(slots=True)
 class ExecutionCompletedEvent(HistoryEvent):
     orchestration_status: int
-    result: Optional[str] = None
-    failure_details: Optional[task.FailureDetails] = None
+    result: str | None = None
+    failure_details: task.FailureDetails | None = None
 
 
 @dataclass(slots=True)
 class ExecutionTerminatedEvent(HistoryEvent):
-    input: Optional[str] = None
+    input: str | None = None
     recurse: bool = False
 
 
 @dataclass(slots=True)
 class TaskScheduledEvent(HistoryEvent):
     name: str
-    version: Optional[str] = None
-    input: Optional[str] = None
-    parent_trace_context: Optional[TraceContext] = None
-    tags: Optional[dict[str, str]] = None
+    version: str | None = None
+    input: str | None = None
+    parent_trace_context: TraceContext | None = None
+    tags: dict[str, str] | None = None
 
 
 @dataclass(slots=True)
 class TaskCompletedEvent(HistoryEvent):
     task_scheduled_id: int
-    result: Optional[str] = None
+    result: str | None = None
 
 
 @dataclass(slots=True)
 class TaskFailedEvent(HistoryEvent):
     task_scheduled_id: int
-    failure_details: Optional[task.FailureDetails] = None
+    failure_details: task.FailureDetails | None = None
 
 
 @dataclass(slots=True)
 class SubOrchestrationInstanceCreatedEvent(HistoryEvent):
     instance_id: str
     name: str
-    version: Optional[str] = None
-    input: Optional[str] = None
-    parent_trace_context: Optional[TraceContext] = None
-    tags: Optional[dict[str, str]] = None
+    version: str | None = None
+    input: str | None = None
+    parent_trace_context: TraceContext | None = None
+    tags: dict[str, str] | None = None
 
 
 @dataclass(slots=True)
 class SubOrchestrationInstanceCompletedEvent(HistoryEvent):
     task_scheduled_id: int
-    result: Optional[str] = None
+    result: str | None = None
 
 
 @dataclass(slots=True)
 class SubOrchestrationInstanceFailedEvent(HistoryEvent):
     task_scheduled_id: int
-    failure_details: Optional[task.FailureDetails] = None
+    failure_details: task.FailureDetails | None = None
 
 
 @dataclass(slots=True)
@@ -138,18 +138,18 @@ class OrchestratorCompletedEvent(HistoryEvent):
 class EventSentEvent(HistoryEvent):
     instance_id: str
     name: str
-    input: Optional[str] = None
+    input: str | None = None
 
 
 @dataclass(slots=True)
 class EventRaisedEvent(HistoryEvent):
     name: str
-    input: Optional[str] = None
+    input: str | None = None
 
 
 @dataclass(slots=True)
 class GenericEvent(HistoryEvent):
-    data: Optional[str] = None
+    data: str | None = None
 
 
 @dataclass(slots=True)
@@ -159,49 +159,49 @@ class HistoryStateEvent(HistoryEvent):
 
 @dataclass(slots=True)
 class ContinueAsNewEvent(HistoryEvent):
-    input: Optional[str] = None
+    input: str | None = None
 
 
 @dataclass(slots=True)
 class ExecutionSuspendedEvent(HistoryEvent):
-    input: Optional[str] = None
+    input: str | None = None
 
 
 @dataclass(slots=True)
 class ExecutionResumedEvent(HistoryEvent):
-    input: Optional[str] = None
+    input: str | None = None
 
 
 @dataclass(slots=True)
 class EntityOperationSignaledEvent(HistoryEvent):
     request_id: str
     operation: str
-    scheduled_time: Optional[datetime] = None
-    input: Optional[str] = None
-    target_instance_id: Optional[str] = None
+    scheduled_time: datetime | None = None
+    input: str | None = None
+    target_instance_id: str | None = None
 
 
 @dataclass(slots=True)
 class EntityOperationCalledEvent(HistoryEvent):
     request_id: str
     operation: str
-    scheduled_time: Optional[datetime] = None
-    input: Optional[str] = None
-    parent_instance_id: Optional[str] = None
-    parent_execution_id: Optional[str] = None
-    target_instance_id: Optional[str] = None
+    scheduled_time: datetime | None = None
+    input: str | None = None
+    parent_instance_id: str | None = None
+    parent_execution_id: str | None = None
+    target_instance_id: str | None = None
 
 
 @dataclass(slots=True)
 class EntityOperationCompletedEvent(HistoryEvent):
     request_id: str
-    output: Optional[str] = None
+    output: str | None = None
 
 
 @dataclass(slots=True)
 class EntityOperationFailedEvent(HistoryEvent):
     request_id: str
-    failure_details: Optional[task.FailureDetails] = None
+    failure_details: task.FailureDetails | None = None
 
 
 @dataclass(slots=True)
@@ -209,7 +209,7 @@ class EntityLockRequestedEvent(HistoryEvent):
     critical_section_id: str
     lock_set: list[str]
     position: int
-    parent_instance_id: Optional[str] = None
+    parent_instance_id: str | None = None
 
 
 @dataclass(slots=True)
@@ -220,21 +220,21 @@ class EntityLockGrantedEvent(HistoryEvent):
 @dataclass(slots=True)
 class EntityUnlockSentEvent(HistoryEvent):
     critical_section_id: str
-    parent_instance_id: Optional[str] = None
-    target_instance_id: Optional[str] = None
+    parent_instance_id: str | None = None
+    target_instance_id: str | None = None
 
 
 @dataclass(slots=True)
 class ExecutionRewoundEvent(HistoryEvent):
-    reason: Optional[str] = None
-    parent_execution_id: Optional[str] = None
-    instance_id: Optional[str] = None
-    parent_trace_context: Optional[TraceContext] = None
-    name: Optional[str] = None
-    version: Optional[str] = None
-    input: Optional[str] = None
-    parent_instance: Optional[ParentInstanceInfo] = None
-    tags: Optional[dict[str, str]] = None
+    reason: str | None = None
+    parent_execution_id: str | None = None
+    instance_id: str | None = None
+    parent_trace_context: TraceContext | None = None
+    name: str | None = None
+    version: str | None = None
+    input: str | None = None
+    parent_instance: ParentInstanceInfo | None = None
+    tags: dict[str, str] | None = None
 
 
 def _from_protobuf(event: pb.HistoryEvent) -> HistoryEvent:
@@ -258,19 +258,19 @@ def _base_kwargs(event: pb.HistoryEvent) -> dict[str, Any]:
     }
 
 
-def _string_value(msg: Message, field_name: str) -> Optional[str]:
+def _string_value(msg: Message, field_name: str) -> str | None:
     if msg.HasField(field_name):
         return getattr(msg, field_name).value
     return None
 
 
-def _timestamp_value(msg: Message, field_name: str) -> Optional[datetime]:
+def _timestamp_value(msg: Message, field_name: str) -> datetime | None:
     if msg.HasField(field_name):
         return getattr(msg, field_name).ToDatetime(timezone.utc)
     return None
 
 
-def _failure_details(msg: Message, field_name: str) -> Optional[task.FailureDetails]:
+def _failure_details(msg: Message, field_name: str) -> task.FailureDetails | None:
     if not msg.HasField(field_name):
         return None
     details = getattr(msg, field_name)
@@ -281,7 +281,7 @@ def _failure_details(msg: Message, field_name: str) -> Optional[task.FailureDeta
     )
 
 
-def _trace_context(msg: Message, field_name: str) -> Optional[TraceContext]:
+def _trace_context(msg: Message, field_name: str) -> TraceContext | None:
     if not msg.HasField(field_name):
         return None
     value = getattr(msg, field_name)
@@ -292,7 +292,7 @@ def _trace_context(msg: Message, field_name: str) -> Optional[TraceContext]:
     )
 
 
-def _orchestration_instance(msg: Message, field_name: str) -> Optional[OrchestrationInstance]:
+def _orchestration_instance(msg: Message, field_name: str) -> OrchestrationInstance | None:
     if not msg.HasField(field_name):
         return None
     value = getattr(msg, field_name)
@@ -302,7 +302,7 @@ def _orchestration_instance(msg: Message, field_name: str) -> Optional[Orchestra
     )
 
 
-def _parent_instance(msg: Message, field_name: str) -> Optional[ParentInstanceInfo]:
+def _parent_instance(msg: Message, field_name: str) -> ParentInstanceInfo | None:
     if not msg.HasField(field_name):
         return None
     value = getattr(msg, field_name)

--- a/durabletask/internal/client_helpers.py
+++ b/durabletask/internal/client_helpers.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 import uuid
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, List, Optional, Sequence, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Sequence, TypeVar
 
 import durabletask.internal.helpers as helpers
 import durabletask.internal.orchestrator_service_pb2 as pb
@@ -31,11 +31,11 @@ TOutput = TypeVar('TOutput')
 
 
 def prepare_sync_interceptors(
-        metadata: Optional[list[tuple[str, str]]],
-        interceptors: Optional[Sequence[shared.ClientInterceptor]]
-) -> Optional[list[shared.ClientInterceptor]]:
+        metadata: list[tuple[str, str]] | None,
+        interceptors: Sequence[shared.ClientInterceptor] | None
+) -> list[shared.ClientInterceptor] | None:
     """Prepare the list of sync gRPC interceptors, adding a metadata interceptor if needed."""
-    result: Optional[list[shared.ClientInterceptor]] = None
+    result: list[shared.ClientInterceptor] | None = None
     if interceptors is not None:
         result = list(interceptors)
         if metadata is not None:
@@ -46,11 +46,11 @@ def prepare_sync_interceptors(
 
 
 def prepare_async_interceptors(
-        metadata: Optional[list[tuple[str, str]]],
-        interceptors: Optional[Sequence[shared.AsyncClientInterceptor]]
-) -> Optional[list[shared.AsyncClientInterceptor]]:
+        metadata: list[tuple[str, str]] | None,
+        interceptors: Sequence[shared.AsyncClientInterceptor] | None
+) -> list[shared.AsyncClientInterceptor] | None:
     """Prepare the list of async gRPC interceptors, adding a metadata interceptor if needed."""
-    result: Optional[list[shared.AsyncClientInterceptor]] = None
+    result: list[shared.AsyncClientInterceptor] | None = None
     if interceptors is not None:
         result = list(interceptors)
         if metadata is not None:
@@ -61,13 +61,13 @@ def prepare_async_interceptors(
 
 
 def build_schedule_new_orchestration_req(
-        orchestrator: Union[task.Orchestrator[TInput, TOutput], str], *,
-        input: Optional[TInput],
-        instance_id: Optional[str],
-        start_at: Optional[datetime],
-        reuse_id_policy: Optional[pb.OrchestrationIdReusePolicy],
-        tags: Optional[dict[str, str]],
-        version: Optional[str]) -> pb.CreateInstanceRequest:
+        orchestrator: task.Orchestrator[TInput, TOutput] | str, *,
+        input: TInput | None,
+        instance_id: str | None,
+        start_at: datetime | None,
+        reuse_id_policy: pb.OrchestrationIdReusePolicy | None,
+        tags: dict[str, str] | None,
+        version: str | None) -> pb.CreateInstanceRequest:
     """Build a CreateInstanceRequest for scheduling a new orchestration."""
     name = orchestrator if isinstance(orchestrator, str) else task.get_name(orchestrator)
     return pb.CreateInstanceRequest(
@@ -98,9 +98,9 @@ def build_query_instances_req(
 
 
 def build_purge_by_filter_req(
-        created_time_from: Optional[datetime],
-        created_time_to: Optional[datetime],
-        runtime_status: Optional[List[OrchestrationStatus]],
+        created_time_from: datetime | None,
+        created_time_to: datetime | None,
+        runtime_status: list[OrchestrationStatus] | None,
         recursive: bool) -> pb.PurgeInstancesRequest:
     """Build a PurgeInstancesRequest for purging orchestrations by filter."""
     return pb.PurgeInstancesRequest(
@@ -144,7 +144,7 @@ def check_continuation_token(resp_token, prev_token, logger: logging.Logger) -> 
 def log_completion_state(
         logger: logging.Logger,
         instance_id: str,
-        state: Optional[OrchestrationState]):
+        state: OrchestrationState | None):
     """Log the final state of a completed orchestration."""
     if not state:
         return
@@ -162,7 +162,7 @@ def log_completion_state(
 def build_raise_event_req(
         instance_id: str,
         event_name: str,
-        data: Optional[Any] = None) -> pb.RaiseEventRequest:
+        data: Any | None = None) -> pb.RaiseEventRequest:
     """Build a RaiseEventRequest for raising an orchestration event."""
     return pb.RaiseEventRequest(
         instanceId=instance_id,
@@ -173,7 +173,7 @@ def build_raise_event_req(
 
 def build_terminate_req(
         instance_id: str,
-        output: Optional[Any] = None,
+        output: Any | None = None,
         recursive: bool = True) -> pb.TerminateRequest:
     """Build a TerminateRequest for terminating an orchestration."""
     return pb.TerminateRequest(
@@ -186,7 +186,7 @@ def build_terminate_req(
 def build_signal_entity_req(
         entity_instance_id: EntityInstanceId,
         operation_name: str,
-        input: Optional[Any] = None) -> pb.SignalEntityRequest:
+        input: Any | None = None) -> pb.SignalEntityRequest:
     """Build a SignalEntityRequest for signaling an entity."""
     return pb.SignalEntityRequest(
         instanceId=str(entity_instance_id),

--- a/durabletask/internal/entity_state_shim.py
+++ b/durabletask/internal/entity_state_shim.py
@@ -1,5 +1,4 @@
-from typing import Any, TypeVar, Union
-from typing import Optional, Type, overload
+from typing import Any, TypeVar, overload
 
 import durabletask.internal.orchestrator_service_pb2 as pb
 
@@ -14,18 +13,18 @@ class StateShim:
         self._actions_checkpoint_state: int = 0
 
     @overload
-    def get_state(self, intended_type: Type[TState], default: TState) -> TState:
+    def get_state(self, intended_type: type[TState], default: TState) -> TState:
         ...
 
     @overload
-    def get_state(self, intended_type: Type[TState]) -> Optional[TState]:
+    def get_state(self, intended_type: type[TState]) -> TState | None:
         ...
 
     @overload
     def get_state(self, intended_type: None = None, default: Any = None) -> Any:
         ...
 
-    def get_state(self, intended_type: Optional[Type[TState]] = None, default: Optional[TState] = None) -> Union[None, TState, Any]:
+    def get_state(self, intended_type: type[TState] | None = None, default: TState | None = None) -> TState | Any | None:
         if self._current_state is None and default is not None:
             return default
 

--- a/durabletask/internal/helpers.py
+++ b/durabletask/internal/helpers.py
@@ -3,7 +3,6 @@
 
 import traceback
 from datetime import datetime
-from typing import Optional
 
 from google.protobuf import timestamp_pb2, wrappers_pb2
 
@@ -13,7 +12,7 @@ import durabletask.internal.orchestrator_service_pb2 as pb
 # TODO: The new_xxx_event methods are only used by test code and should be moved elsewhere
 
 
-def new_orchestrator_started_event(timestamp: Optional[datetime] = None) -> pb.HistoryEvent:
+def new_orchestrator_started_event(timestamp: datetime | None = None) -> pb.HistoryEvent:
     ts = timestamp_pb2.Timestamp()
     if timestamp is not None:
         ts.FromDatetime(timestamp)
@@ -25,10 +24,10 @@ def new_orchestrator_completed_event() -> pb.HistoryEvent:
                            orchestratorCompleted=pb.OrchestratorCompletedEvent())
 
 
-def new_execution_started_event(name: str, instance_id: str, encoded_input: Optional[str] = None,
-                                tags: Optional[dict[str, str]] = None,
-                                version: Optional[str] = None,
-                                parent_trace_context: Optional[pb.TraceContext] = None) -> pb.HistoryEvent:
+def new_execution_started_event(name: str, instance_id: str, encoded_input: str | None = None,
+                                tags: dict[str, str] | None = None,
+                                version: str | None = None,
+                                parent_trace_context: pb.TraceContext | None = None) -> pb.HistoryEvent:
     return pb.HistoryEvent(
         eventId=-1,
         timestamp=timestamp_pb2.Timestamp(),
@@ -61,7 +60,7 @@ def new_timer_fired_event(timer_id: int, fire_at: datetime) -> pb.HistoryEvent:
     )
 
 
-def new_task_scheduled_event(event_id: int, name: str, encoded_input: Optional[str] = None) -> pb.HistoryEvent:
+def new_task_scheduled_event(event_id: int, name: str, encoded_input: str | None = None) -> pb.HistoryEvent:
     return pb.HistoryEvent(
         eventId=event_id,
         timestamp=timestamp_pb2.Timestamp(),
@@ -69,7 +68,7 @@ def new_task_scheduled_event(event_id: int, name: str, encoded_input: Optional[s
     )
 
 
-def new_task_completed_event(event_id: int, encoded_output: Optional[str] = None) -> pb.HistoryEvent:
+def new_task_completed_event(event_id: int, encoded_output: str | None = None) -> pb.HistoryEvent:
     return pb.HistoryEvent(
         eventId=-1,
         timestamp=timestamp_pb2.Timestamp(),
@@ -89,8 +88,8 @@ def new_sub_orchestration_created_event(
         event_id: int,
         name: str,
         instance_id: str,
-        encoded_input: Optional[str] = None,
-        version: Optional[str] = None) -> pb.HistoryEvent:
+        encoded_input: str | None = None,
+        version: str | None = None) -> pb.HistoryEvent:
     return pb.HistoryEvent(
         eventId=event_id,
         timestamp=timestamp_pb2.Timestamp(),
@@ -102,7 +101,7 @@ def new_sub_orchestration_created_event(
     )
 
 
-def new_sub_orchestration_completed_event(event_id: int, encoded_output: Optional[str] = None) -> pb.HistoryEvent:
+def new_sub_orchestration_completed_event(event_id: int, encoded_output: str | None = None) -> pb.HistoryEvent:
     return pb.HistoryEvent(
         eventId=-1,
         timestamp=timestamp_pb2.Timestamp(),
@@ -122,11 +121,11 @@ def new_sub_orchestration_failed_event(event_id: int, ex: Exception) -> pb.Histo
     )
 
 
-def new_failure_details(ex: Exception, _visited: Optional[set[int]] = None) -> pb.TaskFailureDetails:
+def new_failure_details(ex: Exception, _visited: set[int] | None = None) -> pb.TaskFailureDetails:
     if _visited is None:
         _visited = set()
     _visited.add(id(ex))
-    inner: Optional[BaseException] = ex.__cause__ or ex.__context__
+    inner: BaseException | None = ex.__cause__ or ex.__context__
     if len(_visited) > 10 or (inner and id(inner) in _visited) or not isinstance(inner, Exception):
         inner = None
     return pb.TaskFailureDetails(
@@ -149,7 +148,7 @@ def new_event_sent_event(event_id: int, instance_id: str, input: str):
     )
 
 
-def new_event_raised_event(name: str, encoded_input: Optional[str] = None) -> pb.HistoryEvent:
+def new_event_raised_event(name: str, encoded_input: str | None = None) -> pb.HistoryEvent:
     return pb.HistoryEvent(
         eventId=-1,
         timestamp=timestamp_pb2.Timestamp(),
@@ -173,7 +172,7 @@ def new_resume_event() -> pb.HistoryEvent:
     )
 
 
-def new_terminated_event(*, encoded_output: Optional[str] = None) -> pb.HistoryEvent:
+def new_terminated_event(*, encoded_output: str | None = None) -> pb.HistoryEvent:
     return pb.HistoryEvent(
         eventId=-1,
         timestamp=timestamp_pb2.Timestamp(),
@@ -183,21 +182,21 @@ def new_terminated_event(*, encoded_output: Optional[str] = None) -> pb.HistoryE
     )
 
 
-def get_string_value(val: Optional[str]) -> Optional[wrappers_pb2.StringValue]:
+def get_string_value(val: str | None) -> wrappers_pb2.StringValue | None:
     if val is None:
         return None
     else:
         return wrappers_pb2.StringValue(value=val)
 
 
-def get_int_value(val: Optional[int]) -> Optional[wrappers_pb2.Int32Value]:
+def get_int_value(val: int | None) -> wrappers_pb2.Int32Value | None:
     if val is None:
         return None
     else:
         return wrappers_pb2.Int32Value(value=val)
 
 
-def get_string_value_or_empty(val: Optional[str]) -> wrappers_pb2.StringValue:
+def get_string_value_or_empty(val: str | None) -> wrappers_pb2.StringValue:
     if val is None:
         return wrappers_pb2.StringValue(value="")
     return wrappers_pb2.StringValue(value=val)
@@ -206,9 +205,9 @@ def get_string_value_or_empty(val: Optional[str]) -> wrappers_pb2.StringValue:
 def new_complete_orchestration_action(
         id: int,
         status: pb.OrchestrationStatus,
-        result: Optional[str] = None,
-        failure_details: Optional[pb.TaskFailureDetails] = None,
-        carryover_events: Optional[list[pb.HistoryEvent]] = None) -> pb.OrchestratorAction:
+        result: str | None = None,
+        failure_details: pb.TaskFailureDetails | None = None,
+        carryover_events: list[pb.HistoryEvent] | None = None) -> pb.OrchestratorAction:
     completeOrchestrationAction = pb.CompleteOrchestrationAction(
         orchestrationStatus=status,
         result=get_string_value(result),
@@ -224,9 +223,9 @@ def new_create_timer_action(id: int, fire_at: datetime) -> pb.OrchestratorAction
     return pb.OrchestratorAction(id=id, createTimer=pb.CreateTimerAction(fireAt=timestamp))
 
 
-def new_schedule_task_action(id: int, name: str, encoded_input: Optional[str],
-                             tags: Optional[dict[str, str]],
-                             parent_trace_context: Optional[pb.TraceContext] = None) -> pb.OrchestratorAction:
+def new_schedule_task_action(id: int, name: str, encoded_input: str | None,
+                             tags: dict[str, str] | None,
+                             parent_trace_context: pb.TraceContext | None = None) -> pb.OrchestratorAction:
     return pb.OrchestratorAction(id=id, scheduleTask=pb.ScheduleTaskAction(
         name=name,
         input=get_string_value(encoded_input),
@@ -239,7 +238,7 @@ def new_call_entity_action(id: int,
                            parent_instance_id: str,
                            entity_id: EntityInstanceId,
                            operation: str,
-                           encoded_input: Optional[str],
+                           encoded_input: str | None,
                            request_id: str) -> pb.OrchestratorAction:
     return pb.OrchestratorAction(id=id, sendEntityMessage=pb.SendEntityMessageAction(entityOperationCalled=pb.EntityOperationCalledEvent(
         requestId=request_id,
@@ -255,7 +254,7 @@ def new_call_entity_action(id: int,
 def new_signal_entity_action(id: int,
                              entity_id: EntityInstanceId,
                              operation: str,
-                             encoded_input: Optional[str],
+                             encoded_input: str | None,
                              request_id: str) -> pb.OrchestratorAction:
     return pb.OrchestratorAction(id=id, sendEntityMessage=pb.SendEntityMessageAction(entityOperationSignaled=pb.EntityOperationSignaledEvent(
         requestId=request_id,
@@ -304,10 +303,10 @@ def new_timestamp(dt: datetime) -> timestamp_pb2.Timestamp:
 def new_create_sub_orchestration_action(
         id: int,
         name: str,
-        instance_id: Optional[str],
-        encoded_input: Optional[str],
-        version: Optional[str],
-        parent_trace_context: Optional[pb.TraceContext] = None) -> pb.OrchestratorAction:
+        instance_id: str | None,
+        encoded_input: str | None,
+        version: str | None,
+        parent_trace_context: pb.TraceContext | None = None) -> pb.OrchestratorAction:
     return pb.OrchestratorAction(id=id, createSubOrchestration=pb.CreateSubOrchestrationAction(
         name=name,
         instanceId=instance_id,

--- a/durabletask/internal/history_helpers.py
+++ b/durabletask/internal/history_helpers.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import AsyncIterable, Iterable, Optional
+from typing import AsyncIterable, Iterable
 
 import durabletask.history as history
 import durabletask.internal.orchestrator_service_pb2 as pb
@@ -13,7 +13,7 @@ from durabletask.payload.store import PayloadStore
 
 def collect_history_events(
     chunks: Iterable[pb.HistoryChunk],
-    payload_store: Optional[PayloadStore] = None,
+    payload_store: PayloadStore | None = None,
 ) -> list[history.HistoryEvent]:
     events: list[history.HistoryEvent] = []
     for chunk in chunks:
@@ -23,7 +23,7 @@ def collect_history_events(
 
 async def collect_history_events_async(
     chunks: AsyncIterable[pb.HistoryChunk],
-    payload_store: Optional[PayloadStore] = None,
+    payload_store: PayloadStore | None = None,
 ) -> list[history.HistoryEvent]:
     events: list[history.HistoryEvent] = []
     async for chunk in chunks:
@@ -37,7 +37,7 @@ def history_event_to_dict(event: history.HistoryEvent) -> dict:
 
 def _clone_and_convert_events(
     source_events: Iterable[pb.HistoryEvent],
-    payload_store: Optional[PayloadStore],
+    payload_store: PayloadStore | None,
 ) -> list[history.HistoryEvent]:
     events: list[history.HistoryEvent] = []
     for source_event in source_events:
@@ -54,7 +54,7 @@ def _clone_and_convert_events(
 
 async def _clone_and_convert_events_async(
     source_events: Iterable[pb.HistoryEvent],
-    payload_store: Optional[PayloadStore],
+    payload_store: PayloadStore | None,
 ) -> list[history.HistoryEvent]:
     events: list[history.HistoryEvent] = []
     for source_event in source_events:

--- a/durabletask/internal/json_encode_output_exception.py
+++ b/durabletask/internal/json_encode_output_exception.py
@@ -4,7 +4,7 @@ from typing import Any
 class JsonEncodeOutputException(Exception):
     """Custom exception type used to indicate that an orchestration result could not be JSON-encoded."""
 
-    def __init__(self, problem_object: Any):
+    def __init__(self, problem_object: Any) -> None:
         super().__init__()
         self.problem_object = problem_object
 

--- a/durabletask/internal/orchestration_entity_context.py
+++ b/durabletask/internal/orchestration_entity_context.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Generator, List, Optional, Tuple, Union
+from typing import Generator
 
 from durabletask.internal.helpers import get_string_value
 import durabletask.internal.orchestrator_service_pb2 as pb
@@ -25,12 +25,12 @@ class OrchestrationEntityContext:
             for available_lock in self.available_locks:
                 yield available_lock
 
-    def validate_suborchestration_transition(self) -> Tuple[bool, str]:
+    def validate_suborchestration_transition(self) -> tuple[bool, str]:
         if self.is_inside_critical_section:
             return False, "While holding locks, cannot call suborchestrators."
         return True, ""
 
-    def validate_operation_transition(self, target_instance_id: EntityInstanceId, one_way: bool) -> Tuple[bool, str]:
+    def validate_operation_transition(self, target_instance_id: EntityInstanceId, one_way: bool) -> tuple[bool, str]:
         if self.is_inside_critical_section:
             lock_to_use = target_instance_id
             if one_way:
@@ -48,7 +48,7 @@ class OrchestrationEntityContext:
                         return False, "Must not call an entity from a critical section if it is not one of the locked entities."
         return True, ""
 
-    def validate_acquire_transition(self) -> Tuple[bool, str]:
+    def validate_acquire_transition(self) -> tuple[bool, str]:
         if self.is_inside_critical_section:
             return False, "Must not enter another critical section from within a critical section."
         return True, ""
@@ -72,11 +72,15 @@ class OrchestrationEntityContext:
             self.critical_section_id = None
 
     def emit_request_message(self, target, operation_name: str, one_way: bool, operation_id: str,
-                             scheduled_time_utc: datetime, input: Optional[str],
-                             request_time: Optional[datetime] = None, create_trace: bool = False):
+                             scheduled_time_utc: datetime, input: str | None,
+                             request_time: datetime | None = None, create_trace: bool = False):
         raise NotImplementedError()
 
-    def emit_acquire_message(self, critical_section_id: str, entities: List[EntityInstanceId]) -> Union[Tuple[None, None], Tuple[pb.SendEntityMessageAction, pb.OrchestrationInstance]]:
+    def emit_acquire_message(
+        self,
+        critical_section_id: str,
+        entities: list[EntityInstanceId],
+    ) -> tuple[None, None] | tuple[pb.SendEntityMessageAction, pb.OrchestrationInstance]:
         if not entities:
             return None, None
 

--- a/durabletask/internal/shared.py
+++ b/durabletask/internal/shared.py
@@ -4,26 +4,27 @@
 import dataclasses
 import json
 import logging
+from collections.abc import Sequence
 from types import SimpleNamespace
-from typing import Any, Optional, Sequence, Union
+from typing import Any, TypeAlias
 
 import grpc
 import grpc.aio
 from durabletask.grpc_options import GrpcChannelOptions
 
-ClientInterceptor = Union[
-    grpc.UnaryUnaryClientInterceptor,
-    grpc.UnaryStreamClientInterceptor,
-    grpc.StreamUnaryClientInterceptor,
-    grpc.StreamStreamClientInterceptor
-]
+ClientInterceptor: TypeAlias = (
+    grpc.UnaryUnaryClientInterceptor
+    | grpc.UnaryStreamClientInterceptor
+    | grpc.StreamUnaryClientInterceptor
+    | grpc.StreamStreamClientInterceptor
+)
 
-AsyncClientInterceptor = Union[
-    grpc.aio.UnaryUnaryClientInterceptor,
-    grpc.aio.UnaryStreamClientInterceptor,
-    grpc.aio.StreamUnaryClientInterceptor,
-    grpc.aio.StreamStreamClientInterceptor
-]
+AsyncClientInterceptor: TypeAlias = (
+    grpc.aio.UnaryUnaryClientInterceptor
+    | grpc.aio.UnaryStreamClientInterceptor
+    | grpc.aio.StreamUnaryClientInterceptor
+    | grpc.aio.StreamStreamClientInterceptor
+)
 
 # Field name used to indicate that an object was automatically serialized
 # and should be deserialized as a SimpleNamespace
@@ -38,10 +39,10 @@ def get_default_host_address() -> str:
 
 
 def get_grpc_channel(
-        host_address: Optional[str],
+        host_address: str | None,
         secure_channel: bool = False,
-        interceptors: Optional[Sequence[ClientInterceptor]] = None,
-        channel_options: Optional[GrpcChannelOptions] = None) -> grpc.Channel:
+        interceptors: Sequence[ClientInterceptor] | None = None,
+        channel_options: GrpcChannelOptions | None = None) -> grpc.Channel:
 
     if host_address is None:
         host_address = get_default_host_address()
@@ -84,10 +85,10 @@ def get_grpc_channel(
 
 
 def get_async_grpc_channel(
-        host_address: Optional[str],
+        host_address: str | None,
         secure_channel: bool = False,
-        interceptors: Optional[Sequence[AsyncClientInterceptor]] = None,
-        channel_options: Optional[GrpcChannelOptions] = None) -> grpc.aio.Channel:
+        interceptors: Sequence[AsyncClientInterceptor] | None = None,
+        channel_options: GrpcChannelOptions | None = None) -> grpc.aio.Channel:
 
     if host_address is None:
         host_address = get_default_host_address()
@@ -138,8 +139,8 @@ def get_async_grpc_channel(
 
 def get_logger(
         name_suffix: str,
-        log_handler: Optional[logging.Handler] = None,
-        log_formatter: Optional[logging.Formatter] = None) -> logging.Logger:
+        log_handler: logging.Handler | None = None,
+        log_formatter: logging.Formatter | None = None) -> logging.Logger:
     logger = logging.Logger(f"durabletask-{name_suffix}")
 
     # Add a default log handler if none is provided

--- a/durabletask/internal/tracing.py
+++ b/durabletask/internal/tracing.py
@@ -19,7 +19,7 @@ import random
 import time
 from contextlib import contextmanager
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from google.protobuf import timestamp_pb2, wrappers_pb2
 
@@ -102,7 +102,7 @@ CARRIER_KEY_TRACESTATE = "tracestate"
 # ---------------------------------------------------------------------------
 
 def create_span_name(
-    span_type: str, task_name: str, version: Optional[str] = None,
+    span_type: str, task_name: str, version: str | None = None,
 ) -> str:
     """Build a span name with optional version suffix.
 
@@ -126,7 +126,7 @@ def create_timer_span_name(orchestration_name: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _trace_context_from_carrier(carrier: dict[str, str]) -> Optional[pb.TraceContext]:
+def _trace_context_from_carrier(carrier: dict[str, str]) -> pb.TraceContext | None:
     """Build a ``TraceContext`` protobuf from a W3C propagation carrier.
 
     Returns ``None`` when the carrier does not contain a valid
@@ -149,7 +149,7 @@ def _trace_context_from_carrier(carrier: dict[str, str]) -> Optional[pb.TraceCon
     )
 
 
-def _parse_traceparent(traceparent: str) -> Optional[tuple[int, int, int]]:
+def _parse_traceparent(traceparent: str) -> tuple[int, int, int] | None:
     """Parse a W3C traceparent string into ``(trace_id, span_id, trace_flags)``.
 
     Returns ``None`` when the string is not a valid traceparent.
@@ -168,7 +168,7 @@ def _parse_traceparent(traceparent: str) -> Optional[tuple[int, int, int]]:
         return None
 
 
-def get_current_trace_context() -> Optional[pb.TraceContext]:
+def get_current_trace_context() -> pb.TraceContext | None:
     """Capture the current OpenTelemetry span context as a protobuf ``TraceContext``.
 
     Returns ``None`` when OpenTelemetry is not installed or there is no
@@ -183,7 +183,7 @@ def get_current_trace_context() -> Optional[pb.TraceContext]:
     return _trace_context_from_carrier(carrier)
 
 
-def extract_trace_context(proto_ctx: Optional[pb.TraceContext]) -> Optional[Any]:
+def extract_trace_context(proto_ctx: pb.TraceContext | None) -> Any | None:
     """Convert a protobuf ``TraceContext`` into an OpenTelemetry ``Context``.
 
     Returns ``None`` when OpenTelemetry is not installed or the supplied
@@ -208,9 +208,9 @@ def extract_trace_context(proto_ctx: Optional[pb.TraceContext]) -> Optional[Any]
 @contextmanager
 def start_span(
     name: str,
-    trace_context: Optional[pb.TraceContext] = None,
+    trace_context: pb.TraceContext | None = None,
     kind: Any = None,
-    attributes: Optional[dict[str, str]] = None,
+    attributes: dict[str, str] | None = None,
 ):
     """Context manager that starts an OpenTelemetry span linked to a parent trace context.
 
@@ -271,12 +271,12 @@ def set_span_error(span: Any, ex: Exception) -> None:
 def emit_orchestration_span(
     name: str,
     instance_id: str,
-    start_time_ns: Optional[int],
+    start_time_ns: int | None,
     is_failed: bool,
     failure_details: Any = None,
-    parent_trace_context: Optional[pb.TraceContext] = None,
-    orchestration_trace_context: Optional[pb.TraceContext] = None,
-    version: Optional[str] = None,
+    parent_trace_context: pb.TraceContext | None = None,
+    orchestration_trace_context: pb.TraceContext | None = None,
+    version: str | None = None,
 ) -> None:
     """Emit a SERVER span for a completed orchestration (create-and-end).
 
@@ -353,10 +353,10 @@ def emit_orchestration_span(
 def _emit_orchestration_span_deferred(
     span_name: str,
     attrs: dict[str, str],
-    start_time_ns: Optional[int],
+    start_time_ns: int | None,
     is_failed: bool,
     failure_details: Any,
-    parent_trace_context: Optional[pb.TraceContext],
+    parent_trace_context: pb.TraceContext | None,
     orchestration_trace_context: pb.TraceContext,
 ) -> bool:
     """Emit an orchestration SERVER span with a pre-determined span ID.
@@ -494,8 +494,8 @@ def _is_deferred_span_capable() -> bool:
 
 
 def generate_client_trace_context(
-    parent_trace_context: Optional[pb.TraceContext] = None,
-) -> Optional[pb.TraceContext]:
+    parent_trace_context: pb.TraceContext | None = None,
+) -> pb.TraceContext | None:
     """Generate a trace context for a deferred CLIENT span.
 
     Creates a new span ID and builds a W3C traceparent string **without**
@@ -544,12 +544,12 @@ def emit_client_span(
     instance_id: str,
     task_id: int,
     client_trace_context: pb.TraceContext,
-    parent_trace_context: Optional[pb.TraceContext] = None,
-    start_time_ns: Optional[int] = None,
-    end_time_ns: Optional[int] = None,
+    parent_trace_context: pb.TraceContext | None = None,
+    start_time_ns: int | None = None,
+    end_time_ns: int | None = None,
     is_error: bool = False,
-    error_message: Optional[str] = None,
-    version: Optional[str] = None,
+    error_message: str | None = None,
+    version: str | None = None,
 ) -> None:
     """Emit a CLIENT span with a specific span ID reconstructed from history.
 
@@ -665,8 +665,8 @@ def emit_timer_span(
     instance_id: str,
     timer_id: int,
     fire_at: datetime,
-    scheduled_time_ns: Optional[int] = None,
-    parent_trace_context: Optional[pb.TraceContext] = None,
+    scheduled_time_ns: int | None = None,
+    parent_trace_context: pb.TraceContext | None = None,
 ) -> None:
     """Emit an Internal span for a timer (emit-and-close pattern).
 
@@ -712,8 +712,8 @@ def emit_timer_span(
 def emit_event_raised_span(
     event_name: str,
     instance_id: str,
-    target_instance_id: Optional[str] = None,
-    parent_trace_context: Optional[pb.TraceContext] = None,
+    target_instance_id: str | None = None,
+    parent_trace_context: pb.TraceContext | None = None,
 ) -> None:
     """Emit a Producer span for an event raised from the orchestration.
 
@@ -759,7 +759,7 @@ def emit_event_raised_span(
 def start_create_orchestration_span(
     name: str,
     instance_id: str,
-    version: Optional[str] = None,
+    version: str | None = None,
 ):
     """Context manager for a Producer span when scheduling a new orchestration.
 
@@ -817,7 +817,7 @@ def start_raise_event_span(
 def reconstruct_trace_context(
     parent_trace_context: pb.TraceContext,
     span_id: str,
-) -> Optional[pb.TraceContext]:
+) -> pb.TraceContext | None:
     """Reconstruct a ``TraceContext`` with a specific span ID.
 
     Uses the trace ID and flags from *parent_trace_context* but replaces
@@ -839,9 +839,9 @@ def reconstruct_trace_context(
 
 
 def build_orchestration_trace_context(
-    start_time_ns: Optional[int],
-    span_id: Optional[str] = None,
-) -> Optional[pb.OrchestrationTraceContext]:
+    start_time_ns: int | None,
+    span_id: str | None = None,
+) -> pb.OrchestrationTraceContext | None:
     """Build an ``OrchestrationTraceContext`` protobuf to return to the sidecar.
 
     This preserves both the orchestration start time and span ID across

--- a/durabletask/payload/helpers.py
+++ b/durabletask/payload/helpers.py
@@ -12,7 +12,7 @@ matches a known payload-store token (de-externalize).  The actual upload
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from google.protobuf import message as proto_message
 from google.protobuf import wrappers_pb2
@@ -32,7 +32,7 @@ def externalize_payloads(
     msg: proto_message.Message,
     store: PayloadStore,
     *,
-    instance_id: Optional[str] = None,
+    instance_id: str | None = None,
 ) -> None:
     """Walk *msg* in-place, uploading large ``StringValue`` fields to *store*.
 
@@ -64,7 +64,7 @@ async def externalize_payloads_async(
     msg: proto_message.Message,
     store: PayloadStore,
     *,
-    instance_id: Optional[str] = None,
+    instance_id: str | None = None,
 ) -> None:
     """Async version of :func:`externalize_payloads`."""
     threshold = store.options.threshold_bytes
@@ -95,7 +95,7 @@ def _walk_and_externalize(
     store: PayloadStore,
     threshold: int,
     max_bytes: int,
-    instance_id: Optional[str],
+    instance_id: str | None,
 ) -> None:
     for fd in msg.DESCRIPTOR.fields:
         if fd.message_type is None:
@@ -150,7 +150,7 @@ def _try_externalize_field(
     store: PayloadStore,
     threshold: int,
     max_bytes: int,
-    instance_id: Optional[str],
+    instance_id: str | None,
 ) -> None:
     val = sv.value
     if not val:
@@ -228,7 +228,7 @@ async def _walk_and_externalize_async(
     store: PayloadStore,
     threshold: int,
     max_bytes: int,
-    instance_id: Optional[str],
+    instance_id: str | None,
 ) -> None:
     for fd in msg.DESCRIPTOR.fields:
         if fd.message_type is None:
@@ -280,7 +280,7 @@ async def _try_externalize_field_async(
     store: PayloadStore,
     threshold: int,
     max_bytes: int,
-    instance_id: Optional[str],
+    instance_id: str | None,
 ) -> None:
     val = sv.value
     if not val:

--- a/durabletask/payload/store.py
+++ b/durabletask/payload/store.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import abc
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
@@ -45,7 +44,7 @@ class PayloadStore(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def upload(self, data: bytes, *, instance_id: Optional[str] = None) -> str:
+    def upload(self, data: bytes, *, instance_id: str | None = None) -> str:
         """Upload a payload and return a reference token string.
 
         The returned token is a compact string that can be embedded in
@@ -63,7 +62,7 @@ class PayloadStore(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def upload_async(self, data: bytes, *, instance_id: Optional[str] = None) -> str:
+    async def upload_async(self, data: bytes, *, instance_id: str | None = None) -> str:
         """Async version of :meth:`upload`."""
         ...
 

--- a/durabletask/task.py
+++ b/durabletask/task.py
@@ -8,7 +8,7 @@ import logging
 import math
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Generator, Generic, Optional, TypeVar, Union
+from typing import Any, Callable, Generator, Generic, TypeAlias, TypeVar
 
 from durabletask.entities import DurableEntity, EntityInstanceId, EntityLock, EntityContext
 import durabletask.internal.helpers as pbh
@@ -39,7 +39,7 @@ class OrchestrationContext(ABC):
 
     @property
     @abstractmethod
-    def version(self) -> Optional[str]:
+    def version(self) -> str | None:
         """Get the version of the orchestration instance.
 
         This version is set when the orchestration is scheduled and can be used
@@ -47,7 +47,7 @@ class OrchestrationContext(ABC):
 
         Returns
         -------
-        Optional[str]
+        str | None
             The version of the orchestration instance, or None if not set.
         """
         pass
@@ -99,7 +99,7 @@ class OrchestrationContext(ABC):
         pass
 
     @abstractmethod
-    def create_timer(self, fire_at: Union[datetime, timedelta]) -> CancellableTask:
+    def create_timer(self, fire_at: datetime | timedelta) -> CancellableTask:
         """Create a Timer Task to fire after at the specified deadline.
 
         Parameters
@@ -115,21 +115,21 @@ class OrchestrationContext(ABC):
         pass
 
     @abstractmethod
-    def call_activity(self, activity: Union[Activity[TInput, TOutput], str], *,
-                      input: Optional[TInput] = None,
-                      retry_policy: Optional[RetryPolicy] = None,
-                      tags: Optional[dict[str, str]] = None) -> CompletableTask[TOutput]:
+    def call_activity(self, activity: Activity[TInput, TOutput] | str, *,
+                      input: TInput | None = None,
+                      retry_policy: RetryPolicy | None = None,
+                      tags: dict[str, str] | None = None) -> CompletableTask[TOutput]:
         """Schedule an activity for execution.
 
         Parameters
         ----------
-        activity: Union[Activity[TInput, TOutput], str]
+        activity: Activity[TInput, TOutput] | str
             A reference to the activity function to call.
-        input: Optional[TInput]
+        input: TInput | None
             The JSON-serializable input (or None) to pass to the activity.
-        retry_policy: Optional[RetryPolicy]
+        retry_policy: RetryPolicy | None
             The retry policy to use for this activity call.
-        tags: Optional[dict[str, str]]
+        tags: dict[str, str] | None
             Optional tags to associate with the activity invocation.
 
         Returns
@@ -143,7 +143,7 @@ class OrchestrationContext(ABC):
     def call_entity(self,
                     entity: EntityInstanceId,
                     operation: str,
-                    input: Optional[TInput] = None) -> CompletableTask[Any]:
+                    input: TInput | None = None) -> CompletableTask[Any]:
         """Schedule entity function for execution.
 
         Parameters
@@ -152,7 +152,7 @@ class OrchestrationContext(ABC):
             The ID of the entity instance to call.
         operation: str
             The name of the operation to invoke on the entity.
-        input: Optional[TInput]
+        input: TInput | None
             The optional JSON-serializable input to pass to the entity function.
 
         Returns
@@ -167,7 +167,7 @@ class OrchestrationContext(ABC):
             self,
             entity_id: EntityInstanceId,
             operation_name: str,
-            input: Optional[TInput] = None
+            input: TInput | None = None
     ) -> None:
         """Signal an entity function for execution.
 
@@ -177,7 +177,7 @@ class OrchestrationContext(ABC):
             The ID of the entity instance to signal.
         operation_name: str
             The name of the operation to invoke on the entity.
-        input: Optional[TInput]
+        input: TInput | None
             The optional JSON-serializable input to pass to the entity function.
         """
         pass
@@ -203,23 +203,23 @@ class OrchestrationContext(ABC):
         pass
 
     @abstractmethod
-    def call_sub_orchestrator(self, orchestrator: Union[Orchestrator[TInput, TOutput], str], *,
-                              input: Optional[TInput] = None,
-                              instance_id: Optional[str] = None,
-                              retry_policy: Optional[RetryPolicy] = None,
-                              version: Optional[str] = None) -> CompletableTask[TOutput]:
+    def call_sub_orchestrator(self, orchestrator: Orchestrator[TInput, TOutput] | str, *,
+                              input: TInput | None = None,
+                              instance_id: str | None = None,
+                              retry_policy: RetryPolicy | None = None,
+                              version: str | None = None) -> CompletableTask[TOutput]:
         """Schedule sub-orchestrator function for execution.
 
         Parameters
         ----------
         orchestrator: Orchestrator[TInput, TOutput]
             A reference to the orchestrator function to call.
-        input: Optional[TInput]
+        input: TInput | None
             The optional JSON-serializable input to pass to the orchestrator function.
-        instance_id: Optional[str]
+        instance_id: str | None
             A unique ID to use for the sub-orchestration instance. If not specified, a
             random UUID will be used.
-        retry_policy: Optional[RetryPolicy]
+        retry_policy: RetryPolicy | None
             The retry policy to use for this sub-orchestrator call.
 
         Returns
@@ -327,7 +327,7 @@ class ReplaySafeLogger(logging.LoggerAdapter):
 
 
 class FailureDetails:
-    def __init__(self, message: str, error_type: str, stack_trace: Optional[str]):
+    def __init__(self, message: str, error_type: str, stack_trace: str | None):
         self._message = message
         self._error_type = error_type
         self._stack_trace = stack_trace
@@ -341,14 +341,14 @@ class FailureDetails:
         return self._error_type
 
     @property
-    def stack_trace(self) -> Optional[str]:
+    def stack_trace(self) -> str | None:
         return self._stack_trace
 
 
 class TaskFailedError(Exception):
     """Exception type for all orchestration task failures."""
 
-    def __init__(self, message: str, details: Union[pb.TaskFailureDetails, Exception]):
+    def __init__(self, message: str, details: pb.TaskFailureDetails | Exception):
         super().__init__(message)
         if isinstance(details, Exception):
             details = pbh.new_failure_details(details)
@@ -377,8 +377,8 @@ class TaskCancelledError(Exception):
 class Task(ABC, Generic[T]):
     """Abstract base class for asynchronous tasks in a durable orchestration."""
     _result: T
-    _exception: Optional[TaskFailedError]
-    _parent: Optional[CompositeTask[T]]
+    _exception: TaskFailedError | None
+    _parent: CompositeTask[T] | None
 
     def __init__(self) -> None:
         super().__init__()
@@ -476,7 +476,7 @@ class CompletableTask(Task[T]):
         if self._parent is not None:
             self._parent.on_child_completed(self)
 
-    def fail(self, message: str, details: Union[Exception, pb.TaskFailureDetails]):
+    def fail(self, message: str, details: Exception | pb.TaskFailureDetails):
         if self._is_complete:
             raise ValueError('The task has already completed.')
         self._exception = TaskFailedError(message, details)
@@ -491,7 +491,7 @@ class CancellableTask(CompletableTask[T]):
     def __init__(self) -> None:
         super().__init__()
         self._is_cancelled = False
-        self._cancel_handler: Optional[Callable[[], None]] = None
+        self._cancel_handler: Callable[[], None] | None = None
 
     @property
     def is_cancelled(self) -> bool:
@@ -542,7 +542,7 @@ class RetryableTask(CompletableTask[T]):
     def increment_attempt_count(self) -> None:
         self._attempt_count += 1
 
-    def compute_next_delay(self) -> Optional[timedelta]:
+    def compute_next_delay(self) -> timedelta | None:
         if self._attempt_count >= self._retry_policy.max_number_of_attempts:
             return None
 
@@ -567,8 +567,8 @@ class RetryableTask(CompletableTask[T]):
 
 
 class TimerTask(CancellableTask[None]):
-    def __init__(self, final_fire_at: Optional[datetime] = None,
-                 maximum_timer_interval: Optional[timedelta] = None):
+    def __init__(self, final_fire_at: datetime | None = None,
+                 maximum_timer_interval: timedelta | None = None):
         super().__init__()
         self._final_fire_at = final_fire_at
         self._maximum_timer_interval = maximum_timer_interval
@@ -576,7 +576,7 @@ class TimerTask(CancellableTask[None]):
     def set_retryable_parent(self, retryable_task: RetryableTask):
         self._retryable_parent = retryable_task
 
-    def _handle_timer_fired(self, current_utc_datetime: datetime) -> Optional[datetime]:
+    def _handle_timer_fired(self, current_utc_datetime: datetime) -> datetime | None:
         if (self._final_fire_at is not None
                 and self._maximum_timer_interval is not None
                 and current_utc_datetime < self._final_fire_at):
@@ -647,12 +647,12 @@ class ActivityContext:
 
 
 # Orchestrators are generators that yield tasks, receive any type, and return TOutput
-Orchestrator = Callable[[OrchestrationContext, TInput], Union[Generator[Task[Any], Any, TOutput], TOutput]]
+Orchestrator: TypeAlias = Callable[[OrchestrationContext, TInput], Generator[Task[Any], Any, TOutput] | TOutput]
 
 # Activities are simple functions that can be scheduled by orchestrators
-Activity = Callable[[ActivityContext, TInput], TOutput]
+Activity: TypeAlias = Callable[[ActivityContext, TInput], TOutput]
 
-Entity = Union[Callable[[EntityContext, TInput], TOutput], type[DurableEntity]]
+Entity: TypeAlias = Callable[[EntityContext, TInput], TOutput] | type[DurableEntity]
 
 
 class RetryPolicy:
@@ -661,9 +661,9 @@ class RetryPolicy:
     def __init__(self, *,
                  first_retry_interval: timedelta,
                  max_number_of_attempts: int,
-                 backoff_coefficient: Optional[float] = 1.0,
-                 max_retry_interval: Optional[timedelta] = None,
-                 retry_timeout: Optional[timedelta] = None):
+                 backoff_coefficient: float | None = 1.0,
+                 max_retry_interval: timedelta | None = None,
+                 retry_timeout: timedelta | None = None):
         """Creates a new RetryPolicy instance.
 
         Parameters
@@ -672,11 +672,11 @@ class RetryPolicy:
             The retry interval to use for the first retry attempt.
         max_number_of_attempts : int
             The maximum number of retry attempts.
-        backoff_coefficient : Optional[float]
+        backoff_coefficient : float | None
             The backoff coefficient to use for calculating the next retry interval.
-        max_retry_interval : Optional[timedelta]
+        max_retry_interval : timedelta | None
             The maximum retry interval to use for any retry attempt.
-        retry_timeout : Optional[timedelta]
+        retry_timeout : timedelta | None
             The maximum amount of time to spend retrying the operation.
         """
         # validate inputs
@@ -708,17 +708,17 @@ class RetryPolicy:
         return self._max_number_of_attempts
 
     @property
-    def backoff_coefficient(self) -> Optional[float]:
+    def backoff_coefficient(self) -> float | None:
         """The backoff coefficient to use for calculating the next retry interval."""
         return self._backoff_coefficient
 
     @property
-    def max_retry_interval(self) -> Optional[timedelta]:
+    def max_retry_interval(self) -> timedelta | None:
         """The maximum retry interval to use for any retry attempt."""
         return self._max_retry_interval
 
     @property
-    def retry_timeout(self) -> Optional[timedelta]:
+    def retry_timeout(self) -> timedelta | None:
         """The maximum amount of time to spend retrying the operation."""
         return self._retry_timeout
 

--- a/durabletask/testing/in_memory_backend.py
+++ b/durabletask/testing/in_memory_backend.py
@@ -18,7 +18,7 @@ import uuid
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Callable, Optional
+from typing import Callable
 
 import grpc
 from concurrent import futures
@@ -36,19 +36,19 @@ class OrchestrationInstance:
     instance_id: str
     name: str
     status: pb.OrchestrationStatus
-    version: Optional[str] = None
-    input: Optional[str] = None
-    output: Optional[str] = None
-    custom_status: Optional[str] = None
+    version: str | None = None
+    input: str | None = None
+    output: str | None = None
+    custom_status: str | None = None
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     last_updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
-    completed_at: Optional[datetime] = None
-    failure_details: Optional[pb.TaskFailureDetails] = None
+    completed_at: datetime | None = None
+    failure_details: pb.TaskFailureDetails | None = None
     history: list[pb.HistoryEvent] = field(default_factory=list)
     pending_events: list[pb.HistoryEvent] = field(default_factory=list)
     dispatched_events: list[pb.HistoryEvent] = field(default_factory=list)
     completion_token: int = 0
-    tags: Optional[dict[str, str]] = None
+    tags: dict[str, str] | None = None
 
 
 @dataclass
@@ -57,18 +57,18 @@ class ActivityWorkItem:
     instance_id: str
     name: str
     task_id: int
-    input: Optional[str]
+    input: str | None
     completion_token: int
-    version: Optional[str] = None
+    version: str | None = None
 
 
 @dataclass
 class EntityState:
     """Internal entity state stored by the in-memory backend."""
     instance_id: str
-    serialized_state: Optional[str] = None
+    serialized_state: str | None = None
     last_modified_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
-    locked_by: Optional[str] = None
+    locked_by: str | None = None
     pending_operations: list[pb.HistoryEvent] = field(default_factory=list)
     dispatched_operations: list[pb.HistoryEvent] = field(default_factory=list)
     completion_token: int = 0
@@ -86,7 +86,7 @@ class PendingLockRequest:
 class EntityWorkItem:
     """Entity work item that needs to be executed."""
     instance_id: str
-    entity_state: Optional[str]
+    entity_state: str | None
     operations: list[pb.HistoryEvent]
     completion_token: int
 
@@ -96,7 +96,7 @@ class StateWaiter:
     """Promise resolver for waiting on orchestration state changes."""
     predicate: Callable[[OrchestrationInstance], bool]
     event: threading.Event = field(default_factory=threading.Event)
-    result: Optional[OrchestrationInstance] = None
+    result: OrchestrationInstance | None = None
 
 
 _DEFAULT_PAGE_SIZE = 100
@@ -140,7 +140,7 @@ class InMemoryOrchestrationBackend(stubs.TaskHubSidecarServiceServicer):
         self._next_completion_token: int = 1
         self._max_history_size = max_history_size
         self._port = port
-        self._server: Optional[grpc.Server] = None
+        self._server: grpc.Server | None = None
         self._logger = logging.getLogger(__name__)
         self._shutdown_event = threading.Event()
         self._work_available = threading.Event()
@@ -160,7 +160,7 @@ class InMemoryOrchestrationBackend(stubs.TaskHubSidecarServiceServicer):
         self._logger.info(f"In-memory backend started on port {self._port}")
         return f"localhost:{self._port}"
 
-    def stop(self, grace: Optional[float] = None):
+    def stop(self, grace: float | None = None):
         """
         Stops the gRPC server.
 
@@ -531,8 +531,8 @@ class InMemoryOrchestrationBackend(stubs.TaskHubSidecarServiceServicer):
         return orch_filter, activity_filter, entity_filter
 
     @staticmethod
-    def _matches_filter(name: str, version: Optional[str],
-                        filt: Optional[dict[str, frozenset[str]]]) -> bool:
+    def _matches_filter(name: str, version: str | None,
+                        filt: dict[str, frozenset[str]] | None) -> bool:
         """Check whether a work item matches the parsed filter.
 
         *filt* is ``None`` when the worker did not opt into filtering
@@ -1216,8 +1216,8 @@ class InMemoryOrchestrationBackend(stubs.TaskHubSidecarServiceServicer):
         return self._is_terminal_status(instance.status)
 
     def _create_instance_internal(self, instance_id: str, name: str,
-                                  encoded_input: Optional[str] = None,
-                                  version: Optional[str] = None):
+                                  encoded_input: str | None = None,
+                                  version: str | None = None):
         """Creates a new instance directly in internal state (no gRPC context needed)."""
         existing = self._instances.get(instance_id)
         if existing:
@@ -1252,7 +1252,7 @@ class InMemoryOrchestrationBackend(stubs.TaskHubSidecarServiceServicer):
         self._enqueue_orchestration(instance_id)
 
     def _raise_event_internal(self, instance_id: str, event_name: str,
-                              event_data: Optional[str] = None):
+                              event_data: str | None = None):
         """Raises an event directly in internal state (no gRPC context needed)."""
         instance = self._instances.get(instance_id)
         if not instance:
@@ -1263,7 +1263,7 @@ class InMemoryOrchestrationBackend(stubs.TaskHubSidecarServiceServicer):
         instance.last_updated_at = datetime.now(timezone.utc)
         self._enqueue_orchestration(instance.instance_id)
 
-    def _terminate_instance_internal(self, instance_id: str, output: Optional[str],
+    def _terminate_instance_internal(self, instance_id: str, output: str | None,
                                      recursive: bool = False):
         """Internal method to terminate an instance."""
         if recursive:
@@ -1310,7 +1310,7 @@ class InMemoryOrchestrationBackend(stubs.TaskHubSidecarServiceServicer):
 
     def _wait_for_state(self, instance_id: str,
                         predicate: Callable[[OrchestrationInstance], bool],
-                        timeout: Optional[float]) -> Optional[OrchestrationInstance]:
+                        timeout: float | None) -> OrchestrationInstance | None:
         """Waits for an orchestration to reach a state matching the predicate."""
         with self._lock:
             instance = self._instances.get(instance_id)
@@ -1731,7 +1731,7 @@ class InMemoryOrchestrationBackend(stubs.TaskHubSidecarServiceServicer):
         self._enqueue_entity(entity_id)
 
     def _signal_entity_internal(self, entity_id: str, operation: str,
-                                input_value: Optional[str] = None):
+                                input_value: str | None = None):
         """Internal method to signal an entity (from entity side-effect actions)."""
         event = pb.HistoryEvent(
             eventId=-1,

--- a/durabletask/worker.py
+++ b/durabletask/worker.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta, timezone
 from threading import Event, Lock, Thread
 from types import GeneratorType
 from enum import Enum
-from typing import Any, Generator, Optional, Sequence, Tuple, TypeVar, Union, overload
+from typing import Any, Generator, Sequence, TypeVar, overload
 import uuid
 from packaging.version import InvalidVersion, parse
 
@@ -64,10 +64,10 @@ class ConcurrencyOptions:
 
     def __init__(
             self,
-            maximum_concurrent_activity_work_items: Optional[int] = None,
-            maximum_concurrent_orchestration_work_items: Optional[int] = None,
-            maximum_concurrent_entity_work_items: Optional[int] = None,
-            maximum_thread_pool_workers: Optional[int] = None,
+            maximum_concurrent_activity_work_items: int | None = None,
+            maximum_concurrent_orchestration_work_items: int | None = None,
+            maximum_concurrent_entity_work_items: int | None = None,
+            maximum_thread_pool_workers: int | None = None,
     ):
         """Initialize concurrency options.
 
@@ -207,15 +207,15 @@ class VersioningOptions:
     and activities, including whether to use the default version and how to compare versions.
     """
 
-    version: Optional[str] = None
-    default_version: Optional[str] = None
-    match_strategy: Optional[VersionMatchStrategy] = None
-    failure_strategy: Optional[VersionFailureStrategy] = None
+    version: str | None = None
+    default_version: str | None = None
+    match_strategy: VersionMatchStrategy | None = None
+    failure_strategy: VersionFailureStrategy | None = None
 
-    def __init__(self, version: Optional[str] = None,
-                 default_version: Optional[str] = None,
-                 match_strategy: Optional[VersionMatchStrategy] = None,
-                 failure_strategy: Optional[VersionFailureStrategy] = None
+    def __init__(self, version: str | None = None,
+                 default_version: str | None = None,
+                 match_strategy: VersionMatchStrategy | None = None,
+                 failure_strategy: VersionFailureStrategy | None = None
                  ):
         """Initialize versioning options.
 
@@ -338,7 +338,7 @@ class _Registry:
     orchestrators: dict[str, task.Orchestrator]
     activities: dict[str, task.Activity]
     entities: dict[str, task.Entity]
-    versioning: Optional[VersioningOptions] = None
+    versioning: VersioningOptions | None = None
 
     def __init__(self):
         self.orchestrators = {}
@@ -361,7 +361,7 @@ class _Registry:
 
         self.orchestrators[name] = fn
 
-    def get_orchestrator(self, name: str) -> Optional[task.Orchestrator[Any, Any]]:
+    def get_orchestrator(self, name: str) -> task.Orchestrator[Any, Any] | None:
         return self.orchestrators.get(name)
 
     def add_activity(self, fn: task.Activity[TInput, TOutput]) -> str:
@@ -380,10 +380,10 @@ class _Registry:
 
         self.activities[name] = fn
 
-    def get_activity(self, name: str) -> Optional[task.Activity[Any, Any]]:
+    def get_activity(self, name: str) -> task.Activity[Any, Any] | None:
         return self.activities.get(name)
 
-    def add_entity(self, fn: task.Entity, name: Optional[str] = None) -> str:
+    def add_entity(self, fn: task.Entity, name: str | None = None) -> str:
         if fn is None:
             raise ValueError("An entity function argument is required.")
 
@@ -401,7 +401,7 @@ class _Registry:
 
         self.entities[name] = fn
 
-    def get_entity(self, name: str) -> Optional[task.Entity]:
+    def get_entity(self, name: str) -> task.Entity | None:
         return self.entities.get(name)
 
 
@@ -438,25 +438,25 @@ class TaskHubGrpcWorker:
     - Provides logging and monitoring capabilities
 
     Args:
-        host_address (Optional[str], optional): The gRPC endpoint address of the backend service.
+        host_address (str | None, optional): The gRPC endpoint address of the backend service.
             Defaults to the value from environment variables or localhost.
-        metadata (Optional[list[tuple[str, str]]], optional): gRPC metadata to include with
+        metadata (list[tuple[str, str]] | None, optional): gRPC metadata to include with
             requests. Used for authentication and routing. Defaults to None.
         log_handler (optional[logging.Handler]): Custom logging handler for worker logs. Defaults to None.
-        log_formatter (Optional[logging.Formatter], optional): Custom log formatter.
+        log_formatter (logging.Formatter | None, optional): Custom log formatter.
             Defaults to None.
         secure_channel (bool, optional): Whether to use a secure gRPC channel (TLS).
             Defaults to False.
-        channel (Optional[grpc.Channel], optional): Pre-configured gRPC channel to use.
+        channel (grpc.Channel | None, optional): Pre-configured gRPC channel to use.
             If set, host address, secure_channel, interceptors, and channel_options
             are ignored when creating connections.
-        interceptors (Optional[Sequence[shared.ClientInterceptor]], optional): Custom gRPC
+        interceptors (Sequence[shared.ClientInterceptor] | None, optional): Custom gRPC
             interceptors to apply to the channel. Defaults to None.
-        channel_options (Optional[GrpcChannelOptions], optional): Extra low-level gRPC
+        channel_options (GrpcChannelOptions | None, optional): Extra low-level gRPC
             channel configuration including retry/service config options.
-        resiliency_options (Optional[GrpcWorkerResiliencyOptions], optional): Worker-side
+        resiliency_options (GrpcWorkerResiliencyOptions | None, optional): Worker-side
             gRPC resiliency settings retained for reconnect handling.
-        concurrency_options (Optional[ConcurrencyOptions], optional): Configuration for
+        concurrency_options (ConcurrencyOptions | None, optional): Configuration for
             controlling worker concurrency limits. If None, default settings are used.
 
     Attributes:
@@ -509,24 +509,24 @@ class TaskHubGrpcWorker:
             activity function.
     """
 
-    _response_stream: Optional[Any] = None
-    _interceptors: Optional[list[shared.ClientInterceptor]] = None
+    _response_stream: Any | None = None
+    _interceptors: list[shared.ClientInterceptor] | None = None
 
     def __init__(
             self,
             *,
-            host_address: Optional[str] = None,
-            metadata: Optional[list[tuple[str, str]]] = None,
-            log_handler: Optional[logging.Handler] = None,
-            log_formatter: Optional[logging.Formatter] = None,
-            channel: Optional[grpc.Channel] = None,
+            host_address: str | None = None,
+            metadata: list[tuple[str, str]] | None = None,
+            log_handler: logging.Handler | None = None,
+            log_formatter: logging.Formatter | None = None,
+            channel: grpc.Channel | None = None,
             secure_channel: bool = False,
-            interceptors: Optional[Sequence[shared.ClientInterceptor]] = None,
-            channel_options: Optional[GrpcChannelOptions] = None,
-            resiliency_options: Optional[GrpcWorkerResiliencyOptions] = None,
-            concurrency_options: Optional[ConcurrencyOptions] = None,
-            maximum_timer_interval: Optional[timedelta] = DEFAULT_MAXIMUM_TIMER_INTERVAL,
-            payload_store: Optional[PayloadStore] = None,
+            interceptors: Sequence[shared.ClientInterceptor] | None = None,
+            channel_options: GrpcChannelOptions | None = None,
+            resiliency_options: GrpcWorkerResiliencyOptions | None = None,
+            concurrency_options: ConcurrencyOptions | None = None,
+            maximum_timer_interval: timedelta | None = DEFAULT_MAXIMUM_TIMER_INTERVAL,
+            payload_store: PayloadStore | None = None,
     ):
         self._registry = _Registry()
         self._host_address = (
@@ -568,7 +568,7 @@ class TaskHubGrpcWorker:
 
         self._async_worker_manager = _AsyncWorkerManager(self._concurrency_options, self._logger)
         self._maximum_timer_interval = maximum_timer_interval
-        self._work_item_filters: Optional[WorkItemFilters] = None
+        self._work_item_filters: WorkItemFilters | None = None
         self._auto_generate_work_item_filters: bool = False
 
     @property
@@ -577,7 +577,7 @@ class TaskHubGrpcWorker:
         return self._concurrency_options
 
     @property
-    def maximum_timer_interval(self) -> Optional[timedelta]:
+    def maximum_timer_interval(self) -> timedelta | None:
         """Get the configured maximum timer interval for long timer chunking."""
         return self._maximum_timer_interval
 
@@ -621,7 +621,7 @@ class TaskHubGrpcWorker:
             )
         return self._registry.add_activity(fn)
 
-    def add_entity(self, fn: task.Entity, name: Optional[str] = None) -> str:
+    def add_entity(self, fn: task.Entity, name: str | None = None) -> str:
         """Registers an entity function with the worker."""
         if self._is_running:
             raise RuntimeError(
@@ -649,7 +649,7 @@ class TaskHubGrpcWorker:
 
     def use_work_item_filters(
         self,
-        filters: Union[WorkItemFilters, None, object] = _AUTO_GENERATE_FILTERS,
+        filters: WorkItemFilters | None | object = _AUTO_GENERATE_FILTERS,
     ) -> None:
         """Configures work item filters for the worker.
 
@@ -1071,7 +1071,7 @@ class TaskHubGrpcWorker:
     def _execute_orchestrator(
             self,
             req: pb.OrchestratorRequest,
-            stub: Union[stubs.TaskHubSidecarServiceStub, ProtoTaskHubSidecarServiceStub],
+            stub: stubs.TaskHubSidecarServiceStub | ProtoTaskHubSidecarServiceStub,
             completionToken,
     ):
         instance_id = req.instanceId
@@ -1202,7 +1202,7 @@ class TaskHubGrpcWorker:
     def _cancel_orchestrator(
             self,
             req: pb.OrchestratorRequest,
-            stub: Union[stubs.TaskHubSidecarServiceStub, ProtoTaskHubSidecarServiceStub],
+            stub: stubs.TaskHubSidecarServiceStub | ProtoTaskHubSidecarServiceStub,
             completionToken,
     ):
         stub.AbandonTaskOrchestratorWorkItem(
@@ -1215,7 +1215,7 @@ class TaskHubGrpcWorker:
     def _execute_activity(
             self,
             req: pb.ActivityRequest,
-            stub: Union[stubs.TaskHubSidecarServiceStub, ProtoTaskHubSidecarServiceStub],
+            stub: stubs.TaskHubSidecarServiceStub | ProtoTaskHubSidecarServiceStub,
             completionToken,
     ):
         instance_id = req.orchestrationInstance.instanceId
@@ -1272,7 +1272,7 @@ class TaskHubGrpcWorker:
     def _cancel_activity(
             self,
             req: pb.ActivityRequest,
-            stub: Union[stubs.TaskHubSidecarServiceStub, ProtoTaskHubSidecarServiceStub],
+            stub: stubs.TaskHubSidecarServiceStub | ProtoTaskHubSidecarServiceStub,
             completionToken,
     ):
         stub.AbandonTaskActivityWorkItem(
@@ -1284,8 +1284,8 @@ class TaskHubGrpcWorker:
 
     def _execute_entity_batch(
             self,
-            req: Union[pb.EntityBatchRequest, pb.EntityRequest],
-            stub: Union[stubs.TaskHubSidecarServiceStub, ProtoTaskHubSidecarServiceStub],
+            req: pb.EntityBatchRequest | pb.EntityRequest,
+            stub: stubs.TaskHubSidecarServiceStub | ProtoTaskHubSidecarServiceStub,
             completionToken,
     ):
         operation_infos: list[pb.OperationInfo] = []
@@ -1378,8 +1378,8 @@ class TaskHubGrpcWorker:
 
     def _cancel_entity_batch(
             self,
-            req: Union[pb.EntityBatchRequest, pb.EntityRequest],
-            stub: Union[stubs.TaskHubSidecarServiceStub, ProtoTaskHubSidecarServiceStub],
+            req: pb.EntityBatchRequest | pb.EntityRequest,
+            stub: stubs.TaskHubSidecarServiceStub | ProtoTaskHubSidecarServiceStub,
             completionToken,
     ):
         stub.AbandonTaskEntityWorkItem(
@@ -1391,13 +1391,13 @@ class TaskHubGrpcWorker:
 
 
 class _RuntimeOrchestrationContext(task.OrchestrationContext):
-    _generator: Optional[Generator[task.Task, Any, Any]]
-    _previous_task: Optional[task.Task]
+    _generator: Generator[task.Task, Any, Any] | None
+    _previous_task: task.Task | None
 
     def __init__(self,
                  instance_id: str,
                  registry: _Registry,
-                 maximum_timer_interval: Optional[timedelta] = DEFAULT_MAXIMUM_TIMER_INTERVAL,
+                 maximum_timer_interval: timedelta | None = DEFAULT_MAXIMUM_TIMER_INTERVAL,
                  ):
         self._generator = None
         self._is_replaying = True
@@ -1416,15 +1416,15 @@ class _RuntimeOrchestrationContext(task.OrchestrationContext):
         self._instance_id = instance_id
         self._registry = registry
         self._entity_context = OrchestrationEntityContext(instance_id)
-        self._version: Optional[str] = None
-        self._completion_status: Optional[pb.OrchestrationStatus] = None
+        self._version: str | None = None
+        self._completion_status: pb.OrchestrationStatus | None = None
         self._received_events: dict[str, list[Any]] = {}
         self._pending_events: dict[str, list[task.CancellableTask]] = {}
-        self._new_input: Optional[Any] = None
+        self._new_input: Any | None = None
         self._save_events = False
-        self._encoded_custom_status: Optional[str] = None
-        self._parent_trace_context: Optional[pb.TraceContext] = None
-        self._orchestration_trace_context: Optional[pb.TraceContext] = None
+        self._encoded_custom_status: str | None = None
+        self._parent_trace_context: pb.TraceContext | None = None
+        self._orchestration_trace_context: pb.TraceContext | None = None
         self._maximum_timer_interval = maximum_timer_interval
 
     def run(self, generator: Generator[task.Task, Any, Any]):
@@ -1480,7 +1480,7 @@ class _RuntimeOrchestrationContext(task.OrchestrationContext):
         # self._pending_actions.clear()  # Cancel any pending actions
 
         self._result = result
-        result_json: Optional[str] = None
+        result_json: str | None = None
         if result is not None:
             try:
                 result_json = result if is_result_encoded else shared.to_json(result)
@@ -1494,7 +1494,7 @@ class _RuntimeOrchestrationContext(task.OrchestrationContext):
         )
         self._pending_actions[action.id] = action
 
-    def set_failed(self, ex: Union[Exception, pb.TaskFailureDetails]):
+    def set_failed(self, ex: Exception | pb.TaskFailureDetails):
         if self._is_complete:
             return
 
@@ -1536,7 +1536,7 @@ class _RuntimeOrchestrationContext(task.OrchestrationContext):
         current_actions = list(self._pending_actions.values())
         if self._completion_status == pb.ORCHESTRATION_STATUS_CONTINUED_AS_NEW:
             # When continuing-as-new, we only return a single completion action.
-            carryover_events: Optional[list[pb.HistoryEvent]] = None
+            carryover_events: list[pb.HistoryEvent] | None = None
             if self._save_events:
                 carryover_events = []
                 # We need to save the current set of pending events so that they can be
@@ -1571,7 +1571,7 @@ class _RuntimeOrchestrationContext(task.OrchestrationContext):
         return self._instance_id
 
     @property
-    def version(self) -> Optional[str]:
+    def version(self) -> str | None:
         return self._version
 
     @property
@@ -1591,13 +1591,13 @@ class _RuntimeOrchestrationContext(task.OrchestrationContext):
             shared.to_json(custom_status) if custom_status is not None else None
         )
 
-    def create_timer(self, fire_at: Union[datetime, timedelta]) -> task.CancellableTask:
+    def create_timer(self, fire_at: datetime | timedelta) -> task.CancellableTask:
         return self.create_timer_internal(fire_at)
 
     def create_timer_internal(
             self,
-            fire_at: Union[datetime, timedelta],
-            retryable_task: Optional[task.RetryableTask] = None,
+            fire_at: datetime | timedelta,
+            retryable_task: task.RetryableTask | None = None,
     ) -> task.TimerTask:
         id = self.next_sequence_number()
         if isinstance(fire_at, timedelta):
@@ -1632,11 +1632,11 @@ class _RuntimeOrchestrationContext(task.OrchestrationContext):
 
     def call_activity(
             self,
-            activity: Union[task.Activity[TInput, TOutput], str],
+            activity: task.Activity[TInput, TOutput] | str,
             *,
-            input: Optional[TInput] = None,
-            retry_policy: Optional[task.RetryPolicy] = None,
-            tags: Optional[dict[str, str]] = None,
+            input: TInput | None = None,
+            retry_policy: task.RetryPolicy | None = None,
+            tags: dict[str, str] | None = None,
     ) -> task.CompletableTask[TOutput]:
         id = self.next_sequence_number()
 
@@ -1649,7 +1649,7 @@ class _RuntimeOrchestrationContext(task.OrchestrationContext):
             self,
             entity: EntityInstanceId,
             operation: str,
-            input: Optional[TInput] = None,
+            input: TInput | None = None,
     ) -> task.CompletableTask[Any]:
         id = self.next_sequence_number()
 
@@ -1663,7 +1663,7 @@ class _RuntimeOrchestrationContext(task.OrchestrationContext):
             self,
             entity_id: EntityInstanceId,
             operation_name: str,
-            input: Optional[TInput] = None
+            input: TInput | None = None
     ) -> None:
         id = self.next_sequence_number()
 
@@ -1681,12 +1681,12 @@ class _RuntimeOrchestrationContext(task.OrchestrationContext):
 
     def call_sub_orchestrator(
             self,
-            orchestrator: Union[task.Orchestrator[TInput, TOutput], str],
+            orchestrator: task.Orchestrator[TInput, TOutput] | str,
             *,
-            input: Optional[TInput] = None,
-            instance_id: Optional[str] = None,
-            retry_policy: Optional[task.RetryPolicy] = None,
-            version: Optional[str] = None,
+            input: TInput | None = None,
+            instance_id: str | None = None,
+            retry_policy: task.RetryPolicy | None = None,
+            version: str | None = None,
     ) -> task.CompletableTask[TOutput]:
         id = self.next_sequence_number()
         if isinstance(orchestrator, str):
@@ -1708,16 +1708,16 @@ class _RuntimeOrchestrationContext(task.OrchestrationContext):
 
     def call_activity_function_helper(
             self,
-            id: Optional[int],
-            activity_function: Union[task.Activity[TInput, TOutput], str],
+            id: int | None,
+            activity_function: task.Activity[TInput, TOutput] | str,
             *,
-            input: Optional[TInput] = None,
-            retry_policy: Optional[task.RetryPolicy] = None,
-            tags: Optional[dict[str, str]] = None,
+            input: TInput | None = None,
+            retry_policy: task.RetryPolicy | None = None,
+            tags: dict[str, str] | None = None,
             is_sub_orch: bool = False,
-            instance_id: Optional[str] = None,
-            fn_task: Optional[task.CompletableTask[TOutput]] = None,
-            version: Optional[str] = None,
+            instance_id: str | None = None,
+            fn_task: task.CompletableTask[TOutput] | None = None,
+            version: str | None = None,
     ):
         if id is None:
             id = self.next_sequence_number()
@@ -1783,11 +1783,11 @@ class _RuntimeOrchestrationContext(task.OrchestrationContext):
 
     def call_entity_function_helper(
             self,
-            id: Optional[int],
+            id: int | None,
             entity_id: EntityInstanceId,
             operation: str,
             *,
-            input: Optional[TInput] = None,
+            input: TInput | None = None,
     ):
         if id is None:
             id = self.next_sequence_number()
@@ -1805,10 +1805,10 @@ class _RuntimeOrchestrationContext(task.OrchestrationContext):
 
     def signal_entity_function_helper(
             self,
-            id: Optional[int],
+            id: int | None,
             entity_id: EntityInstanceId,
             operation: str,
-            input: Optional[TInput]
+            input: TInput | None
     ) -> None:
         if id is None:
             id = self.next_sequence_number()
@@ -1910,12 +1910,12 @@ class _RuntimeOrchestrationContext(task.OrchestrationContext):
 
 class ExecutionResults:
     actions: list[pb.OrchestratorAction]
-    encoded_custom_status: Optional[str]
-    _orchestration_trace_context: Optional[pb.TraceContext]
+    encoded_custom_status: str | None
+    _orchestration_trace_context: pb.TraceContext | None
 
     def __init__(
-            self, actions: list[pb.OrchestratorAction], encoded_custom_status: Optional[str],
-            orchestration_trace_context: Optional[pb.TraceContext] = None,
+            self, actions: list[pb.OrchestratorAction], encoded_custom_status: str | None,
+            orchestration_trace_context: pb.TraceContext | None = None,
     ):
         self.actions = actions
         self.encoded_custom_status = encoded_custom_status
@@ -1923,14 +1923,14 @@ class ExecutionResults:
 
 
 class _OrchestrationExecutor:
-    _generator: Optional[task.Orchestrator] = None
+    _generator: task.Orchestrator | None = None
 
     def __init__(
         self,
         registry: _Registry,
         logger: logging.Logger,
-        persisted_orch_span_id: Optional[str] = None,
-        maximum_timer_interval: Optional[timedelta] = DEFAULT_MAXIMUM_TIMER_INTERVAL,
+        persisted_orch_span_id: str | None = None,
+        maximum_timer_interval: timedelta | None = DEFAULT_MAXIMUM_TIMER_INTERVAL,
     ):
         self._registry = registry
         self._logger = logger
@@ -1939,12 +1939,12 @@ class _OrchestrationExecutor:
         self._suspended_events: list[pb.HistoryEvent] = []
         self._persisted_orch_span_id = persisted_orch_span_id
         # Maps timer_id -> (fire_at, created_time_ns)
-        self._timer_fire_at: dict[int, tuple[datetime, Optional[int]]] = {}
+        self._timer_fire_at: dict[int, tuple[datetime, int | None]] = {}
         # Maps task_id -> (task_type, name, instance_id, scheduled_ns,
         #                  client_trace_ctx, version)
         # Used to reconstruct CLIENT spans with proper timestamps.
         self._task_scheduled_info: dict[
-            int, tuple[str, str, str, Optional[int], pb.TraceContext, Optional[str]]
+            int, tuple[str, str, str, int | None, pb.TraceContext, str | None]
         ] = {}
 
     def execute(
@@ -2407,7 +2407,7 @@ class _OrchestrationExecutor:
                     if not ctx.is_replaying:
                         self._logger.info(f"{ctx.instance_id} Event raised: {event_name}")
                     task_list = ctx._pending_events.get(event_name, None)
-                    decoded_result: Optional[Any] = None
+                    decoded_result: Any | None = None
                     if task_list:
                         event_task = task_list.pop(0)
                         if not ph.is_empty(event.eventRaised.input):
@@ -2600,7 +2600,7 @@ class _OrchestrationExecutor:
             # The orchestrator generator function completed
             ctx.set_complete(generatorStopped.value, pb.ORCHESTRATION_STATUS_COMPLETED)
 
-    def _parse_entity_event_sent_input(self, event: pb.HistoryEvent) -> Tuple[EntityInstanceId, str]:
+    def _parse_entity_event_sent_input(self, event: pb.HistoryEvent) -> tuple[EntityInstanceId, str]:
         try:
             entity_id = EntityInstanceId.parse(event.eventSent.instanceId)
         except ValueError:
@@ -2614,8 +2614,8 @@ class _OrchestrationExecutor:
     def _handle_entity_event_raised(self,
                                     ctx: _RuntimeOrchestrationContext,
                                     event: pb.HistoryEvent,
-                                    entity_id: Optional[EntityInstanceId],
-                                    task_id: Optional[int],
+                                    entity_id: EntityInstanceId | None,
+                                    task_id: int | None,
                                     is_lock_event: bool):
         # This eventRaised represents the result of an entity operation after being translated to the old
         # entity protocol by the Durable WebJobs extension
@@ -2638,7 +2638,7 @@ class _OrchestrationExecutor:
             entity_task.complete(result)
         ctx.resume()
 
-    def evaluate_orchestration_versioning(self, versioning: Optional[VersioningOptions], orchestration_version: Optional[str]) -> Optional[pb.TaskFailureDetails]:
+    def evaluate_orchestration_versioning(self, versioning: VersioningOptions | None, orchestration_version: str | None) -> pb.TaskFailureDetails | None:
         if versioning is None:
             return None
         version_comparison = self.compare_versions(orchestration_version, versioning.version)
@@ -2666,7 +2666,7 @@ class _OrchestrationExecutor:
                 isNonRetriable=True,
             )
 
-    def compare_versions(self, source_version: Optional[str], default_version: Optional[str]) -> int:
+    def compare_versions(self, source_version: str | None, default_version: str | None) -> int:
         if not source_version and not default_version:
             return 0
         if not source_version:
@@ -2691,8 +2691,8 @@ class _ActivityExecutor:
             orchestration_id: str,
             name: str,
             task_id: int,
-            encoded_input: Optional[str],
-    ) -> Optional[str]:
+            encoded_input: str | None,
+    ) -> str | None:
         """Executes an activity function and returns the serialized result, if any."""
         self._logger.debug(
             f"{orchestration_id}/{task_id}: Executing activity '{name}'..."
@@ -2731,8 +2731,8 @@ class _EntityExecutor:
             entity_id: EntityInstanceId,
             operation: str,
             state: StateShim,
-            encoded_input: Optional[str],
-    ) -> Optional[str]:
+            encoded_input: str | None,
+    ) -> str | None:
         """Executes an entity function and returns the serialized result, if any."""
         self._logger.debug(
             f"{orchestration_id}: Executing entity '{entity_id}'..."
@@ -2822,16 +2822,17 @@ def _get_wrong_action_name_error(
 
 def _get_method_name_for_action(action: pb.OrchestratorAction) -> str:
     action_type = action.WhichOneof("orchestratorActionType")
-    if action_type == "scheduleTask":
-        return task.get_name(task.OrchestrationContext.call_activity)
-    elif action_type == "createTimer":
-        return task.get_name(task.OrchestrationContext.create_timer)
-    elif action_type == "createSubOrchestration":
-        return task.get_name(task.OrchestrationContext.call_sub_orchestrator)
-    # elif action_type == "sendEvent":
-    #    return task.get_name(task.OrchestrationContext.send_event)
-    else:
-        raise NotImplementedError(f"Action type '{action_type}' not supported!")
+    match action_type:
+        case "scheduleTask":
+            return task.get_name(task.OrchestrationContext.call_activity)
+        case "createTimer":
+            return task.get_name(task.OrchestrationContext.create_timer)
+        case "createSubOrchestration":
+            return task.get_name(task.OrchestrationContext.call_sub_orchestrator)
+        # case "sendEvent":
+        #    return task.get_name(task.OrchestrationContext.send_event)
+        case _:
+            raise NotImplementedError(f"Action type '{action_type}' not supported!")
 
 
 def _get_new_event_summary(new_events: Sequence[pb.HistoryEvent]) -> str:
@@ -2879,10 +2880,10 @@ class _AsyncWorkerManager:
         self.orchestration_semaphore = None
         self.entity_semaphore = None
         # Don't create queues here - defer until we have an event loop
-        self.activity_queue: Optional[asyncio.Queue] = None
-        self.orchestration_queue: Optional[asyncio.Queue] = None
-        self.entity_batch_queue: Optional[asyncio.Queue] = None
-        self._queue_event_loop: Optional[asyncio.AbstractEventLoop] = None
+        self.activity_queue: asyncio.Queue | None = None
+        self.orchestration_queue: asyncio.Queue | None = None
+        self.entity_batch_queue: asyncio.Queue | None = None
+        self._queue_event_loop: asyncio.AbstractEventLoop | None = None
         # Store work items when no event loop is available
         self._pending_activity_work: list = []
         self._pending_orchestration_work: list = []

--- a/durabletask/worker.py
+++ b/durabletask/worker.py
@@ -442,7 +442,7 @@ class TaskHubGrpcWorker:
             Defaults to the value from environment variables or localhost.
         metadata (list[tuple[str, str]] | None, optional): gRPC metadata to include with
             requests. Used for authentication and routing. Defaults to None.
-        log_handler (optional[logging.Handler]): Custom logging handler for worker logs. Defaults to None.
+        log_handler (logging.Handler | None, optional): Custom logging handler for worker logs. Defaults to None.
         log_formatter (logging.Formatter | None, optional): Custom log formatter.
             Defaults to None.
         secure_channel (bool, optional): Whether to use a secure gRPC channel (TLS).

--- a/examples/entities/function_based_entity.py
+++ b/examples/entities/function_based_entity.py
@@ -1,7 +1,6 @@
 """End-to-end sample that demonstrates how to configure an orchestrator
 that calls an activity function in a sequence and prints the outputs."""
 import os
-from typing import Optional
 
 from azure.identity import DefaultAzureCredential
 
@@ -10,7 +9,7 @@ from durabletask.azuremanaged.client import DurableTaskSchedulerClient
 from durabletask.azuremanaged.worker import DurableTaskSchedulerWorker
 
 
-def counter(ctx: entities.EntityContext, input: int) -> Optional[int]:
+def counter(ctx: entities.EntityContext, input: int) -> int | None:
     if ctx.operation == "set":
         ctx.set_state(input)
     elif ctx.operation == "add":

--- a/examples/entities/function_based_entity_actions.py
+++ b/examples/entities/function_based_entity_actions.py
@@ -1,7 +1,6 @@
 """End-to-end sample that demonstrates how to configure an orchestrator
 that calls an activity function in a sequence and prints the outputs."""
 import os
-from typing import Optional
 
 from azure.identity import DefaultAzureCredential
 
@@ -10,7 +9,7 @@ from durabletask.azuremanaged.client import DurableTaskSchedulerClient
 from durabletask.azuremanaged.worker import DurableTaskSchedulerWorker
 
 
-def counter(ctx: entities.EntityContext, input: int) -> Optional[int]:
+def counter(ctx: entities.EntityContext, input: int) -> int | None:
     if ctx.operation == "set":
         ctx.set_state(input)
     elif ctx.operation == "add":

--- a/tests/durabletask/test_activity_executor.py
+++ b/tests/durabletask/test_activity_executor.py
@@ -3,7 +3,7 @@
 
 import json
 import logging
-from typing import Any, Optional, Tuple
+from typing import Any
 
 from durabletask import task, worker
 
@@ -40,7 +40,7 @@ def test_activity_not_registered():
 
     executor, _ = _get_activity_executor(test_activity)
 
-    caught_exception: Optional[Exception] = None
+    caught_exception: Exception | None = None
     try:
         executor.execute(TEST_INSTANCE_ID, "Bogus", TEST_TASK_ID, None)
     except Exception as ex:
@@ -50,7 +50,7 @@ def test_activity_not_registered():
     assert "Bogus" in str(caught_exception)
 
 
-def _get_activity_executor(fn: task.Activity) -> Tuple[worker._ActivityExecutor, str]:
+def _get_activity_executor(fn: task.Activity) -> tuple[worker._ActivityExecutor, str]:
     registry = worker._Registry()
     name = registry.add_activity(fn)
     executor = worker._ActivityExecutor(registry, TEST_LOGGER)

--- a/tests/durabletask/test_large_payload.py
+++ b/tests/durabletask/test_large_payload.py
@@ -3,7 +3,6 @@
 
 """Tests for large-payload externalization and de-externalization."""
 
-from typing import Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -51,14 +50,14 @@ class FakePayloadStore(PayloadStore):
     def options(self) -> LargePayloadStorageOptions:
         return self._options
 
-    def upload(self, data: bytes, *, instance_id: Optional[str] = None) -> str:
+    def upload(self, data: bytes, *, instance_id: str | None = None) -> str:
         self._counter += 1
         blob_name = f"blob-{self._counter}"
         token = f"{self.TOKEN_PREFIX}{blob_name}"
         self._blobs[token] = data
         return token
 
-    async def upload_async(self, data: bytes, *, instance_id: Optional[str] = None) -> str:
+    async def upload_async(self, data: bytes, *, instance_id: str | None = None) -> str:
         return self.upload(data, instance_id=instance_id)
 
     def download(self, token: str) -> bytes:


### PR DESCRIPTION
## Summary

The repo declares `requires-python = ">=3.10"`, but most hand-written modules still used pre-3.10 typing constructs (`Optional[...]`, `Union[...]`, `List[...]`, `Dict[...]`, `Tuple[...]`, `Type[...]`, etc.). This PR is a pure refactor that brings the hand-written code in line with modern Python 3.10+ syntax.

No public API or runtime behavior changes — purely a typing / dispatch modernization.

## Changes

### PEP 604 — `X | Y` union syntax

Replaced every `Optional[X]` with `X | None` and `Union[X, Y]` with `X | Y` in function signatures, attribute annotations, return types, and docstrings (where they matched).

```python
# before
def foo(x: Optional[int]) -> Union[str, bytes]: ...

# after
def foo(x: int | None) -> str | bytes: ...
```

### PEP 585 — built-in generic collections

`typing.List`, `typing.Dict`, `typing.Tuple`, `typing.Type` are now the built-in lowercase generics.

```python
# before
items: List[OrchestrationStatus]
mapping: Dict[str, int]
pair: Tuple[str, str]
cls: Type[DurableEntity]

# after
items: list[OrchestrationStatus]
mapping: dict[str, int]
pair: tuple[str, str]
cls: type[DurableEntity]
```

### PEP 613 — `TypeAlias` for module-level aliases

Module-level type aliases now use the explicit `TypeAlias` annotation so static checkers recognize them as aliases rather than runtime assignments:

- `durabletask/task.py` — `Orchestrator`, `Activity`, `Entity`
- `durabletask/internal/shared.py` — `ClientInterceptor`, `AsyncClientInterceptor`

```python
# before
ClientInterceptor = Union[
    grpc.UnaryUnaryClientInterceptor,
    grpc.UnaryStreamClientInterceptor,
    ...
]

# after
ClientInterceptor: TypeAlias = (
    grpc.UnaryUnaryClientInterceptor
    | grpc.UnaryStreamClientInterceptor
    | ...
)
```

### PEP 634 — structural pattern matching

Converted `_get_method_name_for_action()` in `worker.py` from an `if/elif` chain dispatching on a string to a `match`/`case` block — the canonical Python 3.10+ form for tag-style dispatch:

```python
# before
def _get_method_name_for_action(action: pb.OrchestratorAction) -> str:
    action_type = action.WhichOneof("orchestratorActionType")
    if action_type == "scheduleTask":
        return task.get_name(task.OrchestrationContext.call_activity)
    elif action_type == "createTimer":
        return task.get_name(task.OrchestrationContext.create_timer)
    elif action_type == "createSubOrchestration":
        return task.get_name(task.OrchestrationContext.call_sub_orchestrator)
    else:
        raise NotImplementedError(...)

# after
def _get_method_name_for_action(action: pb.OrchestratorAction) -> str:
    action_type = action.WhichOneof("orchestratorActionType")
    match action_type:
        case "scheduleTask":
            return task.get_name(task.OrchestrationContext.call_activity)
        case "createTimer":
            return task.get_name(task.OrchestrationContext.create_timer)
        case "createSubOrchestration":
            return task.get_name(task.OrchestrationContext.call_sub_orchestrator)
        case _:
            raise NotImplementedError(...)
```

The two other `if/elif` chains I considered (`worker.py:2281`, `worker.py:2389`, `shared.py:186`) are `isinstance` chains where `match`/`case` would not improve readability and were left alone.

### Import cleanup

Removed now-unused `typing` imports (`Optional`, `Union`, `List`, `Dict`, `Tuple`, `Type`) across all modified files.

## Files **not** modified

- `durabletask/internal/orchestrator_service_pb2.py`
- `durabletask/internal/orchestrator_service_pb2.pyi`
- `durabletask/internal/orchestrator_service_pb2_grpc.py`
- `durabletask/internal/proto_task_hub_sidecar_service_stub.py` — hand-written, but mirrors the generated grpc stub and is validated by `test_proto_task_hub_shim.py` via `get_type_hints()`. Touching it risks breaking that compatibility check.

PEP 695 (`class Foo[T]:`) and broader `typing` → `collections.abc` migrations were intentionally out of scope (PEP 695 needs 3.12+; `collections.abc` swaps are noisy in unrelated files).

## Verification

- ✅ `python -m flake8 durabletask durabletask-azuremanaged examples tests` — clean
- ✅ `python -m pytest tests/durabletask` — **354 passed**, 11 skipped. The 2 failures and 19 errors are environmental (missing `aiohttp` and no sidecar at `localhost:4001`) and reproduce on `main`.
- ✅ `test_proto_task_hub_shim_is_compatible` still passes — confirms the proto stub annotations still resolve at runtime via `get_type_hints()`.

## Changelog

None — internal refactor with no user-visible behavior or public API change, per the repo's CHANGELOG guidance.
