### PR TITLE
Separate 1.6.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 N/A
 
-## 1.6.0
+## v1.6.0
 
 ADDED
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+N/A
+
+## 1.6.0
+
 ADDED
 
 - Added overridable activity-dispatch hooks `_on_activity_execution_started`

--- a/durabletask-azuremanaged/CHANGELOG.md
+++ b/durabletask-azuremanaged/CHANGELOG.md
@@ -9,7 +9,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 N/A
 
-## 1.6.0
+## v1.6.0
 
 - Updates base dependency to durabletask v1.6.0.
 - Added preview support for Durable Task Scheduler on-demand sandbox

--- a/durabletask-azuremanaged/CHANGELOG.md
+++ b/durabletask-azuremanaged/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+N/A
+
+## 1.6.0
+
 - Updates base dependency to durabletask v1.6.0.
 - Added preview support for Durable Task Scheduler on-demand sandbox
   activities under `durabletask.azuremanaged.preview.sandboxes`. Applications


### PR DESCRIPTION
Splits the 1.6.0 changelog at the released point