### PR TITLE
Replace fixed test ports with free port helper

### DIFF
--- a/tests/durabletask/__init__.py
+++ b/tests/durabletask/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.

--- a/tests/durabletask/_port_utils.py
+++ b/tests/durabletask/_port_utils.py
@@ -15,22 +15,15 @@ import socket
 
 
 def find_free_port() -> int:
-    """Return a TCP port number that is currently free.
+    """Return a free TCP port by binding to port 0 and reading the assignment.
 
-    Binds a socket to port 0 so the OS assigns an available port, then
-    releases it and returns the chosen number. There is an inherent race
-    between releasing the socket and the caller binding the port, but in
-    practice it is reliable for tests and far safer than fixed ports.
-
-    The in-memory backend binds the IPv6 wildcard (``[::]``), so the probe
-    uses an IPv6 socket to mirror that bind and avoid returning a port that
-    is free on IPv4 but already in use on IPv6. If IPv6 is unavailable, it
-    falls back to IPv4.
+    Probes IPv6 loopback first to match the backend's ``[::]`` bind (so an
+    IPv6-occupied port isn't wrongly reported free), falling back to IPv4.
     """
     if socket.has_ipv6:
         try:
             with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
-                s.bind(("::", 0))
+                s.bind(("::1", 0))
                 return s.getsockname()[1]
         except OSError:
             pass  # IPv6 not usable on this host; fall back to IPv4.

--- a/tests/durabletask/_port_utils.py
+++ b/tests/durabletask/_port_utils.py
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Shared test helpers for picking network ports.
+
+Tests start an in-memory backend that binds a TCP port. Hard-coding
+fixed ports causes intermittent failures on Windows because Hyper-V (and
+other components) reserve large, dynamic ranges of TCP ports. Asking the
+OS for a free port avoids those collisions.
+"""
+
+from __future__ import annotations
+
+import socket
+
+
+def find_free_port() -> int:
+    """Return a TCP port number that is currently free.
+
+    Binds a socket to port 0 so the OS assigns an available port, then
+    releases it and returns the chosen number. There is an inherent race
+    between releasing the socket and the caller binding the port, but in
+    practice it is reliable for tests and far safer than fixed ports.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("localhost", 0))
+        return s.getsockname()[1]

--- a/tests/durabletask/_port_utils.py
+++ b/tests/durabletask/_port_utils.py
@@ -21,7 +21,20 @@ def find_free_port() -> int:
     releases it and returns the chosen number. There is an inherent race
     between releasing the socket and the caller binding the port, but in
     practice it is reliable for tests and far safer than fixed ports.
+
+    The in-memory backend binds the IPv6 wildcard (``[::]``), so the probe
+    uses an IPv6 socket to mirror that bind and avoid returning a port that
+    is free on IPv4 but already in use on IPv6. If IPv6 is unavailable, it
+    falls back to IPv4.
     """
+    if socket.has_ipv6:
+        try:
+            with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+                s.bind(("::", 0))
+                return s.getsockname()[1]
+        except OSError:
+            pass  # IPv6 not usable on this host; fall back to IPv4.
+
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("localhost", 0))
+        s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]

--- a/tests/durabletask/entities/test_class_based_entities_e2e.py
+++ b/tests/durabletask/entities/test_class_based_entities_e2e.py
@@ -12,13 +12,16 @@ import pytest
 from durabletask import client, entities, task, worker
 from durabletask.testing import create_test_backend
 
-HOST = "localhost:50059"
+from _port_utils import find_free_port
+
+PORT = find_free_port()
+HOST = f"localhost:{PORT}"
 
 
 @pytest.fixture(autouse=True)
 def backend():
     """Create an in-memory backend for entity testing."""
-    b = create_test_backend(port=50059)
+    b = create_test_backend(port=PORT)
     yield b
     b.stop()
     b.reset()

--- a/tests/durabletask/entities/test_class_based_entities_e2e.py
+++ b/tests/durabletask/entities/test_class_based_entities_e2e.py
@@ -12,7 +12,7 @@ import pytest
 from durabletask import client, entities, task, worker
 from durabletask.testing import create_test_backend
 
-from _port_utils import find_free_port
+from tests.durabletask._port_utils import find_free_port
 
 PORT = find_free_port()
 HOST = f"localhost:{PORT}"

--- a/tests/durabletask/entities/test_entity_failure_handling.py
+++ b/tests/durabletask/entities/test_entity_failure_handling.py
@@ -12,7 +12,7 @@ import pytest
 from durabletask import client, entities, task, worker
 from durabletask.testing import create_test_backend
 
-from _port_utils import find_free_port
+from tests.durabletask._port_utils import find_free_port
 
 PORT = find_free_port()
 HOST = f"localhost:{PORT}"

--- a/tests/durabletask/entities/test_entity_failure_handling.py
+++ b/tests/durabletask/entities/test_entity_failure_handling.py
@@ -12,13 +12,16 @@ import pytest
 from durabletask import client, entities, task, worker
 from durabletask.testing import create_test_backend
 
-HOST = "localhost:50057"
+from _port_utils import find_free_port
+
+PORT = find_free_port()
+HOST = f"localhost:{PORT}"
 
 
 @pytest.fixture(autouse=True)
 def backend():
     """Create an in-memory backend for entity testing."""
-    b = create_test_backend(port=50057)
+    b = create_test_backend(port=PORT)
     yield b
     b.stop()
     b.reset()

--- a/tests/durabletask/entities/test_function_based_entities_e2e.py
+++ b/tests/durabletask/entities/test_function_based_entities_e2e.py
@@ -12,7 +12,7 @@ import pytest
 from durabletask import client, entities, task, worker
 from durabletask.testing import create_test_backend
 
-from _port_utils import find_free_port
+from tests.durabletask._port_utils import find_free_port
 
 PORT = find_free_port()
 HOST = f"localhost:{PORT}"

--- a/tests/durabletask/entities/test_function_based_entities_e2e.py
+++ b/tests/durabletask/entities/test_function_based_entities_e2e.py
@@ -12,13 +12,16 @@ import pytest
 from durabletask import client, entities, task, worker
 from durabletask.testing import create_test_backend
 
-HOST = "localhost:50056"
+from _port_utils import find_free_port
+
+PORT = find_free_port()
+HOST = f"localhost:{PORT}"
 
 
 @pytest.fixture(autouse=True)
 def backend():
     """Create an in-memory backend for entity testing."""
-    b = create_test_backend(port=50056)
+    b = create_test_backend(port=PORT)
     yield b
     b.stop()
     b.reset()

--- a/tests/durabletask/extensions/history_export/test_activities.py
+++ b/tests/durabletask/extensions/history_export/test_activities.py
@@ -36,7 +36,7 @@ from durabletask.extensions.history_export.activities import (
 )
 from durabletask.testing import create_test_backend
 
-from _port_utils import find_free_port
+from tests.durabletask._port_utils import find_free_port
 
 PORT = find_free_port()
 HOST = f"localhost:{PORT}"

--- a/tests/durabletask/extensions/history_export/test_activities.py
+++ b/tests/durabletask/extensions/history_export/test_activities.py
@@ -36,8 +36,9 @@ from durabletask.extensions.history_export.activities import (
 )
 from durabletask.testing import create_test_backend
 
+from _port_utils import find_free_port
 
-PORT = 50261
+PORT = find_free_port()
 HOST = f"localhost:{PORT}"
 
 

--- a/tests/durabletask/extensions/history_export/test_client.py
+++ b/tests/durabletask/extensions/history_export/test_client.py
@@ -35,7 +35,7 @@ from durabletask.extensions.history_export.activities import clear_context
 from durabletask.testing import create_test_backend
 
 from ._test_helpers import wait_until
-from _port_utils import find_free_port
+from tests.durabletask._port_utils import find_free_port
 
 PORT = find_free_port()
 HOST = f"localhost:{PORT}"

--- a/tests/durabletask/extensions/history_export/test_client.py
+++ b/tests/durabletask/extensions/history_export/test_client.py
@@ -35,9 +35,9 @@ from durabletask.extensions.history_export.activities import clear_context
 from durabletask.testing import create_test_backend
 
 from ._test_helpers import wait_until
+from _port_utils import find_free_port
 
-
-PORT = 50263
+PORT = find_free_port()
 HOST = f"localhost:{PORT}"
 
 

--- a/tests/durabletask/extensions/history_export/test_entity.py
+++ b/tests/durabletask/extensions/history_export/test_entity.py
@@ -31,7 +31,7 @@ from durabletask.extensions.history_export.entity import (
 from durabletask.testing import create_test_backend
 
 from ._test_helpers import wait_until
-from _port_utils import find_free_port
+from tests.durabletask._port_utils import find_free_port
 
 PORT = find_free_port()
 HOST = f"localhost:{PORT}"

--- a/tests/durabletask/extensions/history_export/test_entity.py
+++ b/tests/durabletask/extensions/history_export/test_entity.py
@@ -31,9 +31,9 @@ from durabletask.extensions.history_export.entity import (
 from durabletask.testing import create_test_backend
 
 from ._test_helpers import wait_until
+from _port_utils import find_free_port
 
-
-PORT = 50260
+PORT = find_free_port()
 HOST = f"localhost:{PORT}"
 
 _WINDOW_START = datetime(2025, 1, 1, tzinfo=timezone.utc)

--- a/tests/durabletask/extensions/history_export/test_orchestrator.py
+++ b/tests/durabletask/extensions/history_export/test_orchestrator.py
@@ -33,9 +33,9 @@ from durabletask.extensions.history_export import orchestrator as orch_mod
 from durabletask.testing import create_test_backend
 
 from ._test_helpers import wait_until
+from _port_utils import find_free_port
 
-
-PORT = 50262
+PORT = find_free_port()
 HOST = f"localhost:{PORT}"
 
 

--- a/tests/durabletask/extensions/history_export/test_orchestrator.py
+++ b/tests/durabletask/extensions/history_export/test_orchestrator.py
@@ -33,7 +33,7 @@ from durabletask.extensions.history_export import orchestrator as orch_mod
 from durabletask.testing import create_test_backend
 
 from ._test_helpers import wait_until
-from _port_utils import find_free_port
+from tests.durabletask._port_utils import find_free_port
 
 PORT = find_free_port()
 HOST = f"localhost:{PORT}"

--- a/tests/durabletask/test_batch_actions.py
+++ b/tests/durabletask/test_batch_actions.py
@@ -15,7 +15,9 @@ from durabletask.client import TaskHubGrpcClient
 from durabletask.testing import create_test_backend
 from durabletask.worker import TaskHubGrpcWorker
 
-BATCH_TEST_PORT = 50058
+from _port_utils import find_free_port
+
+BATCH_TEST_PORT = find_free_port()
 HOST = f"localhost:{BATCH_TEST_PORT}"
 
 

--- a/tests/durabletask/test_batch_actions.py
+++ b/tests/durabletask/test_batch_actions.py
@@ -15,7 +15,7 @@ from durabletask.client import TaskHubGrpcClient
 from durabletask.testing import create_test_backend
 from durabletask.worker import TaskHubGrpcWorker
 
-from _port_utils import find_free_port
+from tests.durabletask._port_utils import find_free_port
 
 BATCH_TEST_PORT = find_free_port()
 HOST = f"localhost:{BATCH_TEST_PORT}"

--- a/tests/durabletask/test_large_payload_e2e.py
+++ b/tests/durabletask/test_large_payload_e2e.py
@@ -22,7 +22,7 @@ import pytest
 from durabletask import client, task, worker
 from durabletask.testing import create_test_backend
 
-from _port_utils import find_free_port
+from tests.durabletask._port_utils import find_free_port
 
 # Skip the entire module if azure-storage-blob is not installed.
 azure_blob = pytest.importorskip("azure.storage.blob")

--- a/tests/durabletask/test_large_payload_e2e.py
+++ b/tests/durabletask/test_large_payload_e2e.py
@@ -22,6 +22,8 @@ import pytest
 from durabletask import client, task, worker
 from durabletask.testing import create_test_backend
 
+from _port_utils import find_free_port
+
 # Skip the entire module if azure-storage-blob is not installed.
 azure_blob = pytest.importorskip("azure.storage.blob")
 
@@ -30,8 +32,8 @@ from durabletask.extensions.azure_blob_payloads import BlobPayloadStore, BlobPay
 # Azurite well-known connection string
 AZURITE_CONN_STR = "UseDevelopmentStorage=true"
 
-HOST = "localhost:50070"
-BACKEND_PORT = 50070
+BACKEND_PORT = find_free_port()
+HOST = f"localhost:{BACKEND_PORT}"
 
 # Use a unique container per test run to avoid collisions.
 TEST_CONTAINER = f"e2e-payloads-{uuid.uuid4().hex[:8]}"

--- a/tests/durabletask/test_orchestration_async_e2e.py
+++ b/tests/durabletask/test_orchestration_async_e2e.py
@@ -9,7 +9,7 @@ import pytest
 from durabletask import client, task, worker
 from durabletask.testing import create_test_backend
 
-from _port_utils import find_free_port
+from tests.durabletask._port_utils import find_free_port
 
 PORT = find_free_port()
 HOST = f"localhost:{PORT}"

--- a/tests/durabletask/test_orchestration_async_e2e.py
+++ b/tests/durabletask/test_orchestration_async_e2e.py
@@ -9,13 +9,16 @@ import pytest
 from durabletask import client, task, worker
 from durabletask.testing import create_test_backend
 
-HOST = "localhost:50060"
+from _port_utils import find_free_port
+
+PORT = find_free_port()
+HOST = f"localhost:{PORT}"
 
 
 @pytest.fixture(autouse=True)
 def backend():
     """Create an in-memory backend for testing."""
-    b = create_test_backend(port=50060)
+    b = create_test_backend(port=PORT)
     yield b
     b.stop()
     b.reset()

--- a/tests/durabletask/test_orchestration_e2e.py
+++ b/tests/durabletask/test_orchestration_e2e.py
@@ -13,13 +13,16 @@ from durabletask import client, task, worker
 import durabletask.history as history
 from durabletask.testing import create_test_backend
 
-HOST = "localhost:50054"
+from _port_utils import find_free_port
+
+PORT = find_free_port()
+HOST = f"localhost:{PORT}"
 
 
 @pytest.fixture(autouse=True)
 def backend():
     """Create an in-memory backend for testing."""
-    b = create_test_backend(port=50054)
+    b = create_test_backend(port=PORT)
     yield b
     b.stop()
     b.reset()

--- a/tests/durabletask/test_orchestration_e2e.py
+++ b/tests/durabletask/test_orchestration_e2e.py
@@ -13,7 +13,7 @@ from durabletask import client, task, worker
 import durabletask.history as history
 from durabletask.testing import create_test_backend
 
-from _port_utils import find_free_port
+from tests.durabletask._port_utils import find_free_port
 
 PORT = find_free_port()
 HOST = f"localhost:{PORT}"

--- a/tests/durabletask/test_orchestration_versioning_e2e.py
+++ b/tests/durabletask/test_orchestration_versioning_e2e.py
@@ -8,7 +8,7 @@ import pytest
 from durabletask import client, task, worker
 from durabletask.testing import create_test_backend
 
-from _port_utils import find_free_port
+from tests.durabletask._port_utils import find_free_port
 
 PORT = find_free_port()
 HOST = f"localhost:{PORT}"

--- a/tests/durabletask/test_orchestration_versioning_e2e.py
+++ b/tests/durabletask/test_orchestration_versioning_e2e.py
@@ -8,13 +8,16 @@ import pytest
 from durabletask import client, task, worker
 from durabletask.testing import create_test_backend
 
-HOST = "localhost:50055"
+from _port_utils import find_free_port
+
+PORT = find_free_port()
+HOST = f"localhost:{PORT}"
 
 
 @pytest.fixture(autouse=True)
 def backend():
     """Create an in-memory backend for testing."""
-    b = create_test_backend(port=50055)
+    b = create_test_backend(port=PORT)
     yield b
     b.stop()
     b.reset()

--- a/tests/durabletask/test_work_item_filters_e2e.py
+++ b/tests/durabletask/test_work_item_filters_e2e.py
@@ -18,7 +18,7 @@ from durabletask.worker import (
 )
 from durabletask.testing import create_test_backend
 
-from _port_utils import find_free_port
+from tests.durabletask._port_utils import find_free_port
 
 PORT = find_free_port()
 HOST = f"localhost:{PORT}"

--- a/tests/durabletask/test_work_item_filters_e2e.py
+++ b/tests/durabletask/test_work_item_filters_e2e.py
@@ -18,13 +18,16 @@ from durabletask.worker import (
 )
 from durabletask.testing import create_test_backend
 
-HOST = "localhost:50060"
+from _port_utils import find_free_port
+
+PORT = find_free_port()
+HOST = f"localhost:{PORT}"
 
 
 @pytest.fixture(autouse=True)
 def backend():
     """Create an in-memory backend for testing."""
-    b = create_test_backend(port=50060)
+    b = create_test_backend(port=PORT)
     yield b
     b.stop()
     b.reset()


### PR DESCRIPTION
Replaces fixed port numbers used by the unit tests and in-memory backend to use a shared helper that finds a free port - minimizing flaky test failures and Windows Hyper-V port conflict issues