### PR TITLE
Release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## v1.7.0
+
 ADDED
 
 - Added `durabletask.scheduled`, a recurring schedule feature built on durable

--- a/durabletask-azuremanaged/CHANGELOG.md
+++ b/durabletask-azuremanaged/CHANGELOG.md
@@ -9,6 +9,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## v1.7.0
 
+- Updates base dependency to durabletask v1.7.0.
+
 ADDED
 
 - `DurableTaskSchedulerWorker`, `DurableTaskSchedulerClient`, and the async

--- a/durabletask-azuremanaged/CHANGELOG.md
+++ b/durabletask-azuremanaged/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## v1.7.0
+
 ADDED
 
 - `DurableTaskSchedulerWorker`, `DurableTaskSchedulerClient`, and the async

--- a/durabletask-azuremanaged/pyproject.toml
+++ b/durabletask-azuremanaged/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "durabletask.azuremanaged"
-version = "1.6.0"
+version = "1.7.0"
 description = "Durable Task Python SDK provider implementation for the Azure Durable Task Scheduler"
 keywords = [
     "durable",
@@ -26,13 +26,13 @@ requires-python = ">=3.10"
 license = {file = "LICENSE"}
 readme = "README.md"
 dependencies = [
-    "durabletask>=1.6.0",
+    "durabletask>=1.7.0",
     "azure-identity>=1.19.0"
 ]
 
 [project.optional-dependencies]
 azure-blob-payloads = [
-    "durabletask[azure-blob-payloads]>=1.6.0"
+    "durabletask[azure-blob-payloads]>=1.7.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "durabletask"
-version = "1.6.0"
+version = "1.7.0"
 description = "A Durable Task Client SDK for Python"
 keywords = [
     "durable",


### PR DESCRIPTION
## Summary

Release prep for **v1.7.0** of both SDK packages.

### Version bumps

- `durabletask`: `1.6.0` → `1.7.0` (`pyproject.toml`)
- `durabletask.azuremanaged`: `1.6.0` → `1.7.0` (`durabletask-azuremanaged/pyproject.toml`)
- `durabletask.azuremanaged` dependency floors bumped:
  - `durabletask>=1.7.0`
  - `durabletask[azure-blob-payloads]>=1.7.0`

### Changelogs

- Moved all `## Unreleased` entries into a new `## v1.7.0` section in both `CHANGELOG.md` and `durabletask-azuremanaged/CHANGELOG.md`.
- Kept an empty `## Unreleased` section at the top of each changelog.

### v1.7.0 highlights

**`durabletask`**
- New `durabletask.scheduled` recurring schedule feature built on durable entities.
- Optional `signal_time` parameter for scheduling entity signals from entities, orchestrations, and clients.
- Pluggable `DataConverter` (`durabletask.serialization`) threaded through every payload boundary, with typed payload reconstruction and `to_json()`/`from_json()` hooks. Includes related CHANGED/FIXED/DEPRECATED notes and type-level breaking changes.

**`durabletask.azuremanaged`**
- `DurableTaskSchedulerWorker`, `DurableTaskSchedulerClient`, and the async client now accept and forward a `data_converter` argument.

### Follow-ups (post-merge)

After this PR merges, create the `v1.7.0` and `azuremanaged-v1.7.0` tags, then draft the GitHub releases.