### PR TITLE
Fix FailureDetails JSON serialization and cut v1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## v1.7.2
+
+FIXED
+
+- Fixed history export failing for orchestrations that completed with an error. Events carrying failure information (orchestration completion, activity failure, sub-orchestration failure, and entity operation failure) were not JSON-serializable, causing the `durabletask.extensions.history_export` module to raise `TypeError: Object of type FailureDetails is not JSON serializable`. `FailureDetails` now serializes to a JSON object with `message`, `error_type`, and `stack_trace` fields.
+
 ## v1.7.1
 
 ADDED

--- a/durabletask-azuremanaged/CHANGELOG.md
+++ b/durabletask-azuremanaged/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## v1.7.2
+
+- Updates base dependency to durabletask v1.7.2.
+
 ## v1.7.1
 
 - Updates base dependency to durabletask v1.7.1

--- a/durabletask-azuremanaged/pyproject.toml
+++ b/durabletask-azuremanaged/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "durabletask.azuremanaged"
-version = "1.7.1"
+version = "1.7.2"
 description = "Durable Task Python SDK provider implementation for the Azure Durable Task Scheduler"
 keywords = [
     "durable",
@@ -26,13 +26,13 @@ requires-python = ">=3.10"
 license = {file = "LICENSE"}
 readme = "README.md"
 dependencies = [
-    "durabletask>=1.7.1",
+    "durabletask>=1.7.2",
     "azure-identity>=1.19.0"
 ]
 
 [project.optional-dependencies]
 azure-blob-payloads = [
-    "durabletask[azure-blob-payloads]>=1.7.1"
+    "durabletask[azure-blob-payloads]>=1.7.2"
 ]
 
 [project.urls]

--- a/durabletask/task.py
+++ b/durabletask/task.py
@@ -8,6 +8,7 @@ import logging
 import math
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator, Sequence
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypeVar, cast, overload
 
@@ -449,23 +450,11 @@ class ReplaySafeLogger(_LoggerAdapterBase):
         return self.logger.isEnabledFor(level)
 
 
+@dataclass(frozen=True)
 class FailureDetails:
-    def __init__(self, message: str, error_type: str, stack_trace: str | None):
-        self._message = message
-        self._error_type = error_type
-        self._stack_trace = stack_trace
-
-    @property
-    def message(self) -> str:
-        return self._message
-
-    @property
-    def error_type(self) -> str:
-        return self._error_type
-
-    @property
-    def stack_trace(self) -> str | None:
-        return self._stack_trace
+    message: str
+    error_type: str
+    stack_trace: str | None
 
 
 class TaskFailedError(Exception):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "durabletask"
-version = "1.7.1"
+version = "1.7.2"
 description = "A Durable Task Client SDK for Python"
 keywords = [
     "durable",

--- a/tests/durabletask/extensions/history_export/test_serialization.py
+++ b/tests/durabletask/extensions/history_export/test_serialization.py
@@ -66,6 +66,30 @@ class TestEventToDict:
         assert d["event_id"] == 0
         assert d["timestamp"].startswith("2025-01-01")
 
+    def test_failure_details_is_json_safe(self) -> None:
+        # Regression: FailureDetails-bearing events must serialize to a
+        # JSON-safe dict rather than a raw FailureDetails object.
+        e = history.ExecutionCompletedEvent(
+            event_id=-1,
+            timestamp=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            orchestration_status=3,
+            result=None,
+            failure_details=task.FailureDetails(
+                message="boom", error_type="RuntimeError", stack_trace="trace",
+            ),
+        )
+        d = event_to_dict(e)
+        assert d["failure_details"] == {
+            "message": "boom",
+            "error_type": "RuntimeError",
+            "stack_trace": "trace",
+        }
+        # The full document must be JSON-serializable.
+        fmt = ExportFormat(kind=ExportFormatKind.JSON)
+        out = serialize_history([e], instance_id="fail-1", fmt=fmt)
+        doc = json.loads(out)
+        assert doc["events"][0]["failure_details"]["error_type"] == "RuntimeError"
+
 
 class TestSerializeJson:
     def test_envelope_fields(self) -> None:


### PR DESCRIPTION
## Summary

Fixes a bug where `history_export` fails for any orchestration that completes with an error, and cuts release **v1.7.2**.

`task.FailureDetails` was a plain class (not a dataclass), so `HistoryEvent.to_dict()` (`asdict` + `_to_serializable`) left it as a raw object and `json.dumps` raised:

```
TypeError: Object of type FailureDetails is not JSON serializable
```

This broke `durabletask.extensions.history_export` for four event types that carry failure information:

- `ExecutionCompletedEvent`
- `TaskFailedEvent`
- `SubOrchestrationInstanceFailedEvent`
- `EntityOperationFailedEvent`

## Fix

Converted `FailureDetails` to a `@dataclass(frozen=True)`. This is a root-cause fix rather than a per-call-site workaround:

- Preserves the exact public API — same positional constructor and read-only `message` / `error_type` / `stack_trace` attributes.
- `asdict` now recurses into it automatically, so all four events serialize to `{ "message", "error_type", "stack_trace" }`.
- Adds value equality/hashing as a bonus.

`FailureDetails` was the only non-dataclass, non-primitive nested type in history events; every other nested type (`OrchestrationInstance`, `ParentInstanceInfo`, `TraceContext`) is already a dataclass, so this single change covers the general case.

## Release v1.7.2

- Bumped `durabletask` and `durabletask.azuremanaged` to `1.7.2` (and updated azuremanaged dependency floors).
- Updated both changelogs.

## Tests

- Added `test_failure_details_is_json_safe` in `test_serialization.py`.
- Full core suite (733 passed) and history_export suite (78 passed) green; flake8 clean.
