### PR TITLE
Release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## v1.8.0
+
 ADDED
 
 - Added `TaskHubGrpcClient.rewind_orchestration()` to rewind a failed orchestration instance to its last known good state. Failed activity and sub-orchestration results are removed from the history and the orchestration replays from the last successful checkpoint, retrying only the failed work. The in-memory testing backend supports rewind as well.

--- a/durabletask-azuremanaged/CHANGELOG.md
+++ b/durabletask-azuremanaged/CHANGELOG.md
@@ -7,6 +7,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## v1.8.0
+
+- Updates base dependency to durabletask v1.8.0.
 - Added `rewind_orchestration()` to `DurableTaskSchedulerClient` and `AsyncDurableTaskSchedulerClient` (inherited from the base clients) to rewind a failed orchestration instance to its last known good state.
 - Fixed Durable Task Scheduler workers stopping permanently when the service reset
   the `GetWorkItems` stream.

--- a/durabletask-azuremanaged/pyproject.toml
+++ b/durabletask-azuremanaged/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "durabletask.azuremanaged"
-version = "1.7.2"
+version = "1.8.0"
 description = "Durable Task Python SDK provider implementation for the Azure Durable Task Scheduler"
 keywords = [
     "durable",
@@ -26,13 +26,13 @@ requires-python = ">=3.10"
 license = {file = "LICENSE"}
 readme = "README.md"
 dependencies = [
-    "durabletask>=1.7.2",
+    "durabletask>=1.8.0",
     "azure-identity>=1.19.0"
 ]
 
 [project.optional-dependencies]
 azure-blob-payloads = [
-    "durabletask[azure-blob-payloads]>=1.7.2"
+    "durabletask[azure-blob-payloads]>=1.8.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "durabletask"
-version = "1.7.2"
+version = "1.8.0"
 description = "A Durable Task Client SDK for Python"
 keywords = [
     "durable",


### PR DESCRIPTION
## Summary

Cuts a coordinated **v1.8.0** release for both packages from `main`:

- `durabletask` → tag `v1.8.0`
- `durabletask.azuremanaged` → tag `azuremanaged-v1.8.0`

## Changes

- Bump `durabletask` version `1.7.2` → `1.8.0` (`pyproject.toml`).
- Bump `durabletask.azuremanaged` version `1.7.2` → `1.8.0` and raise dependency floors (`durabletask>=1.8.0`, `durabletask[azure-blob-payloads]>=1.8.0`).
- Move `Unreleased` changelog entries into a new `## v1.8.0` section in both `CHANGELOG.md` and `durabletask-azuremanaged/CHANGELOG.md`.

## Changelog highlights (v1.8.0)

**durabletask**

- ADDED: `TaskHubGrpcClient.rewind_orchestration()`, `Task.result` alias, `bind_context`/`clear_context` exports.
- FIXED: timezone-aware timer scheduling, orchestration version presence check, `genericEvent` replay handling, legacy lock-granted entity response, `when_all` waiting for all children, worker reconnect after `GetWorkItems` stream reset.

**durabletask.azuremanaged**

- Updates base dependency to `durabletask` v1.8.0.
- ADDED: `rewind_orchestration()` on the DTS clients.
- FIXED: DTS workers stopping permanently after a `GetWorkItems` stream reset.

## Commit coverage

- Core (`v1.7.2..HEAD`): #121, #174, #173, #176 — all represented.
- azuremanaged (`azuremanaged-v1.7.2..HEAD`): #121, #176 — all represented.

## Follow-ups (after merge)

- Create tags `v1.8.0` and `azuremanaged-v1.8.0` on the merge commit.
- Draft the two GitHub Releases from those tags.