### PR TITLE
Performance [P1]: Single-flight async Azure token refresh

### DIFF
--- a/durabletask-azuremanaged/CHANGELOG.md
+++ b/durabletask-azuremanaged/CHANGELOG.md
@@ -8,6 +8,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 - `FailureDetails.error_type` now carries the fully-qualified type name (e.g. `durabletask.task.TaskFailedError`) instead of the bare class name, and the new `FailureDetails.is_caused_by()` helper is available (both inherited from durabletask). See the core `durabletask` changelog for details, including the breaking-change notes.
+- Improved async access token refresh concurrency handling to avoid duplicate
+  refresh operations under concurrent access, matching the existing sync
+  behavior.
 
 ## v1.8.0
 

--- a/durabletask-azuremanaged/durabletask/azuremanaged/internal/access_token_manager.py
+++ b/durabletask-azuremanaged/durabletask/azuremanaged/internal/access_token_manager.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+import asyncio
 from datetime import datetime, timedelta, timezone
 from threading import Lock
 
@@ -70,9 +71,35 @@ class AsyncAccessTokenManager:
         self._token = None
         self.expiry_time = None
 
+        # An asyncio.Lock binds itself to the event loop it is first used on, and this
+        # manager may outlive a loop or be shared across loops. Locks are therefore
+        # created lazily per running loop, guarded by a plain threading lock because
+        # different loops may run on different threads.
+        self._refresh_locks: dict[asyncio.AbstractEventLoop, asyncio.Lock] = {}
+        self._refresh_locks_guard = Lock()
+
+    def _get_refresh_lock(self) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        with self._refresh_locks_guard:
+            lock = self._refresh_locks.get(loop)
+            if lock is None:
+                # Discard locks belonging to loops that are no longer usable so the
+                # mapping does not grow without bound.
+                for stale_loop in [
+                        existing for existing in self._refresh_locks if existing.is_closed()]:
+                    del self._refresh_locks[stale_loop]
+                lock = asyncio.Lock()
+                self._refresh_locks[loop] = lock
+            return lock
+
     async def get_access_token(self) -> AccessToken | None:
         if self._token is None or self.is_token_expired():
-            await self.refresh_token()
+            async with self._get_refresh_lock():
+                # Re-check under the lock: a concurrent caller may have already
+                # refreshed the token while this one was waiting, so only a single
+                # credential request is made per refresh window.
+                if self._token is None or self.is_token_expired():
+                    await self.refresh_token()
         return self._token
 
     def is_token_expired(self) -> bool:

--- a/durabletask-azuremanaged/durabletask/azuremanaged/internal/access_token_manager.py
+++ b/durabletask-azuremanaged/durabletask/azuremanaged/internal/access_token_manager.py
@@ -86,8 +86,10 @@ class AsyncAccessTokenManager:
             if lock is None:
                 # Discard locks belonging to loops that are no longer usable so the
                 # mapping does not grow without bound.
-                for stale_loop in [
-                        existing for existing in self._refresh_locks if existing.is_closed()]:
+                stale_loops = [
+                    existing for existing in self._refresh_locks if existing.is_closed()
+                ]
+                for stale_loop in stale_loops:
                     del self._refresh_locks[stale_loop]
                 lock = asyncio.Lock()
                 self._refresh_locks[loop] = lock

--- a/tests/durabletask-azuremanaged/test_durabletask_grpc_interceptor.py
+++ b/tests/durabletask-azuremanaged/test_durabletask_grpc_interceptor.py
@@ -266,10 +266,15 @@ class _FlakyAsyncTokenCredential:
 
 
 class TestAsyncAccessTokenManagerSingleFlight(unittest.IsolatedAsyncioTestCase):
-    async def test_concurrent_cold_start_performs_single_acquisition(self):
+    async def test_deferred_first_acquisition_performs_single_acquisition(self):
         credential = _TestAsyncTokenCredential()
         manager = AsyncAccessTokenManager(credential)
 
+        self.assertEqual(0, credential.calls, "Constructing the manager must not acquire a token")
+
+        # The async manager has always deferred the first acquisition (a constructor
+        # cannot await), so the cold-start burst goes through the same refresh guard
+        # as a later refresh and must likewise be single-flight.
         tokens = await asyncio.gather(*(manager.get_access_token() for _ in range(16)))
 
         self.assertEqual(1, credential.calls)

--- a/tests/durabletask-azuremanaged/test_durabletask_grpc_interceptor.py
+++ b/tests/durabletask-azuremanaged/test_durabletask_grpc_interceptor.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+import asyncio
 import unittest
 from concurrent import futures
 from datetime import datetime, timedelta, timezone
@@ -12,7 +13,10 @@ import grpc
 from azure.core.credentials import AccessToken
 
 from durabletask.azuremanaged.client import DurableTaskSchedulerClient
-from durabletask.azuremanaged.internal.access_token_manager import AccessTokenManager
+from durabletask.azuremanaged.internal.access_token_manager import (
+    AccessTokenManager,
+    AsyncAccessTokenManager,
+)
 from durabletask.azuremanaged.worker import DurableTaskSchedulerWorker
 from durabletask.internal.grpc_interceptor import DefaultClientInterceptorImpl
 from durabletask.internal import orchestrator_service_pb2 as pb
@@ -169,6 +173,104 @@ class TestAccessTokenManagerThreadSafety(unittest.TestCase):
         for thread in threads:
             thread.join()
 
+        self.assertEqual(2, credential.calls)
+
+
+class _CredentialError(Exception):
+    pass
+
+
+class _TestAsyncTokenCredential:
+    def __init__(self, delay: float = 0.02):
+        self.calls = 0
+        self._delay = delay
+
+    async def get_token(self, _scope):
+        # Counting before the await means every coroutine that reaches the credential
+        # is recorded, which is what makes a thundering herd observable.
+        self.calls += 1
+        call_number = self.calls
+        await asyncio.sleep(self._delay)
+        return AccessToken(f"token-{call_number}", int(time.time()) + 3600)
+
+
+class _FlakyAsyncTokenCredential:
+    def __init__(self):
+        self.calls = 0
+        self.fail = True
+
+    async def get_token(self, _scope):
+        self.calls += 1
+        await asyncio.sleep(0)
+        if self.fail:
+            raise _CredentialError("credential unavailable")
+        return AccessToken("token-recovered", int(time.time()) + 3600)
+
+
+class TestAsyncAccessTokenManagerSingleFlight(unittest.IsolatedAsyncioTestCase):
+    async def test_concurrent_cold_start_performs_single_acquisition(self):
+        credential = _TestAsyncTokenCredential()
+        manager = AsyncAccessTokenManager(credential)
+
+        tokens = await asyncio.gather(*(manager.get_access_token() for _ in range(16)))
+
+        self.assertEqual(1, credential.calls)
+        self.assertEqual({"token-1"}, {token.token for token in tokens})
+
+    async def test_concurrent_refresh_performs_single_refresh(self):
+        credential = _TestAsyncTokenCredential()
+        manager = AsyncAccessTokenManager(credential)
+        await manager.get_access_token()
+        self.assertEqual(1, credential.calls)
+
+        manager.expiry_time = datetime.now(timezone.utc) - timedelta(seconds=1)
+
+        tokens = await asyncio.gather(*(manager.get_access_token() for _ in range(16)))
+
+        self.assertEqual(2, credential.calls)
+        self.assertEqual({"token-2"}, {token.token for token in tokens})
+
+    async def test_valid_token_is_returned_without_contacting_credential(self):
+        credential = _TestAsyncTokenCredential()
+        manager = AsyncAccessTokenManager(credential)
+
+        first = await manager.get_access_token()
+        second = await manager.get_access_token()
+
+        self.assertEqual(1, credential.calls)
+        self.assertIs(first, second)
+
+    async def test_credential_failure_propagates_and_does_not_deadlock(self):
+        credential = _FlakyAsyncTokenCredential()
+        manager = AsyncAccessTokenManager(credential)
+
+        results = await asyncio.gather(
+            *(manager.get_access_token() for _ in range(4)), return_exceptions=True)
+
+        self.assertTrue(all(isinstance(result, _CredentialError) for result in results))
+
+        # The guard must have been released on failure so a later attempt can succeed.
+        credential.fail = False
+        token = await manager.get_access_token()
+        self.assertIsNotNone(token)
+        self.assertEqual("token-recovered", token.token)
+
+
+class TestAsyncAccessTokenManagerEventLoopBinding(unittest.TestCase):
+    def test_manager_is_reusable_across_event_loops(self):
+        credential = _TestAsyncTokenCredential(delay=0)
+        manager = AsyncAccessTokenManager(credential)
+
+        first = asyncio.run(manager.get_access_token())
+
+        manager.expiry_time = datetime.now(timezone.utc) - timedelta(seconds=1)
+
+        # The second run uses a distinct event loop; the refresh guard must not stay
+        # bound to the first, now-closed loop.
+        second = asyncio.run(manager.get_access_token())
+
+        self.assertIsNotNone(first)
+        self.assertIsNotNone(second)
         self.assertEqual(2, credential.calls)
 
 


### PR DESCRIPTION
## Summary

`AsyncAccessTokenManager.get_access_token()` checked expiry and awaited
`refresh_token()` with no synchronization. Because
`DTSAsyncDefaultClientInterceptorImpl._intercept_call()` awaits it on **every**
RPC, a burst of concurrent `grpc.aio` calls arriving while the token was
missing or inside its renewal window would each independently hit the
credential — a thundering herd of Entra/credential requests, added latency, and
avoidable throttling pressure. The synchronous `AccessTokenManager` already
guards this with double-checked locking; the async path did not.

This change mirrors that design for the async manager:

- `get_access_token()` now re-checks token validity **after** acquiring a
  refresh guard, so only one coroutine calls the credential per refresh window
  and the rest reuse the result.
- The guard is an `asyncio.Lock` created lazily **per running event loop**
  (kept in a small map guarded by a `threading.Lock`). An `asyncio.Lock` binds
  itself to the loop it is first awaited on, so a single lock created in
  `__init__` would raise if the manager outlived a loop or was shared across
  loops. Locks belonging to closed loops are pruned so the map cannot grow
  without bound.
- The fast path is unchanged: when a cached token is still valid, the outer
  check short-circuits and no lock is touched, so there is no added per-RPC
  overhead.

Failures propagate unchanged — the guard is released via `async with`, so a
credential error surfaces to the caller and a later attempt can still succeed.

### Backwards compatibility

No public API changes. Method signatures, return values, the expiry/renewal
margin behavior, exception propagation, logging, and sync-path thread-safety
are all preserved. The only new members are private (`_get_refresh_lock`,
`_refresh_locks`, `_refresh_locks_guard`).

### Scope

Deliberately narrow, limited to this issue. It does not touch deferred sync
token acquisition (#187) or SDK version lookup caching (#195), which are being
addressed separately in these same files.

## Verification

- **New tests** in `tests/durabletask-azuremanaged/test_durabletask_grpc_interceptor.py`,
  modeled on the existing sync `test_concurrent_refresh_performs_single_refresh`:
  - 16 concurrent cold-start callers result in exactly **1** credential call.
  - 16 concurrent callers after expiry result in exactly **1** refresh.
  - A valid cached token is returned without contacting the credential.
  - A credential failure propagates to waiters and does not deadlock; a
    subsequent attempt succeeds.
  - The manager is reusable across two distinct event loops (guards against
    binding the lock to a dead loop).
- **Confirmed the tests catch the bug**: with the source change reverted, the
  two single-flight tests fail with `1 != 16` and `2 != 17` — exactly the
  duplicate acquisition described in the issue.
- **Provider unit tests**: `test_durabletask_grpc_interceptor.py` +
  `test_sandboxes_extension.py` — 47 passed (42 at baseline, +5 new).
- **Core unit tests**: `tests/durabletask` excluding `*_e2e.py` — 681 passed,
  7 skipped, identical to baseline.
- **flake8** clean on both changed Python files; **pyright** reports 0 errors
  on the changed source; **pymarkdown** introduces no new findings (the two
  MD013 hits on the changelog are pre-existing lines).
- `test_dts_batch_actions.py` fails identically with and without this change
  (11 failures on a clean baseline); it requires a live Durable Task Scheduler
  endpoint.

Fixes #192
