### PR TITLE
Performance [P2]: Defer synchronous Azure token acquisition

### DIFF
--- a/durabletask-azuremanaged/CHANGELOG.md
+++ b/durabletask-azuremanaged/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- `DurableTaskSchedulerClient` and `DurableTaskSchedulerWorker` no longer block on an Azure
+  credential round trip while being constructed. The access token is now acquired on the first
+  request instead, so constructing a client or worker that is never used costs nothing. As a
+  result, credential failures (for example an unavailable managed identity or a misconfigured
+  `DefaultAzureCredential`) now surface from the first request rather than from the constructor.
+  The exception type and message are unchanged; only the timing differs.
 - `FailureDetails.error_type` now carries the fully-qualified type name (e.g. `durabletask.task.TaskFailedError`) instead of the bare class name, and the new `FailureDetails.is_caused_by()` helper is available (both inherited from durabletask). See the core `durabletask` changelog for details, including the breaking-change notes.
 
 ## v1.8.0

--- a/durabletask-azuremanaged/durabletask/azuremanaged/internal/access_token_manager.py
+++ b/durabletask-azuremanaged/durabletask/azuremanaged/internal/access_token_manager.py
@@ -13,6 +13,7 @@ import durabletask.internal.shared as shared
 class AccessTokenManager:
 
     _token: AccessToken | None
+    expiry_time: datetime | None
 
     def __init__(self, token_credential: TokenCredential | None, refresh_interval_seconds: int = 600):
         self._scope = "https://durabletask.io/.default"
@@ -22,12 +23,12 @@ class AccessTokenManager:
         self._credential = token_credential
         self._refresh_lock = Lock()
 
-        if self._credential is not None:
-            self._token = self._credential.get_token(self._scope)
-            self.expiry_time = datetime.fromtimestamp(self._token.expires_on, tz=timezone.utc)
-        else:
-            self._token = None
-            self.expiry_time = None
+        # Token acquisition is deferred to the first get_access_token() call so that
+        # constructing a client or worker does not perform a blocking credential round
+        # trip. The deferred first acquisition still goes through the double-checked
+        # refresh lock below, so it remains single-flight across threads.
+        self._token = None
+        self.expiry_time = None
 
     def get_access_token(self) -> AccessToken | None:
         if self._token is None or self.is_token_expired():

--- a/durabletask-azuremanaged/durabletask/azuremanaged/internal/durabletask_grpc_interceptor.py
+++ b/durabletask-azuremanaged/durabletask/azuremanaged/internal/durabletask_grpc_interceptor.py
@@ -41,13 +41,13 @@ class DTSDefaultClientInterceptorImpl (DefaultClientInterceptorImpl):
             self._metadata.append(("workerid", worker_id))
         super().__init__(self._metadata)
 
+        # Token acquisition is deferred to the first _intercept_call invocation rather
+        # than happening in __init__, so that constructing a client or worker does not
+        # block on a credential round trip before any RPC is made.
         self._token_manager = None
         if token_credential is not None:
             self._token_credential = token_credential
             self._token_manager = AccessTokenManager(token_credential=self._token_credential)
-            access_token = self._token_manager.get_access_token()
-            if access_token is not None:
-                self._upsert_authorization_header(access_token.token)
 
     def _upsert_authorization_header(self, token: str) -> None:
         found = False

--- a/tests/durabletask-azuremanaged/test_durabletask_grpc_interceptor.py
+++ b/tests/durabletask-azuremanaged/test_durabletask_grpc_interceptor.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 from importlib.metadata import version
 import threading
 import time
+from typing import Any
 
 import grpc
 from azure.core.credentials import AccessToken
@@ -37,6 +38,21 @@ class MockTaskHubSidecarServiceServicer(stubs.TaskHubSidecarServiceServicer):
         # Return a mock response
         response = pb.GetInstanceResponse(exists=False)
         return response
+
+
+class _TestTokenCredential:
+    """Minimal TokenCredential stub that counts how often a token is requested."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.calls = 0
+
+    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+        with self._lock:
+            self.calls += 1
+            call_number = self.calls
+        time.sleep(0.02)
+        return AccessToken(f"token-{call_number}", int(time.time()) + 3600)
 
 
 class TestDurableTaskGrpcInterceptor(unittest.TestCase):
@@ -140,34 +156,76 @@ class TestDurableTaskGrpcInterceptor(unittest.TestCase):
         self.assertIn("workerid", metadata)
         self.assertTrue(metadata["workerid"])
 
+    def test_client_construction_does_not_acquire_token(self):
+        """Token acquisition is deferred from construction to the first request."""
+        credential = _TestTokenCredential()
 
-class _TestTokenCredential:
-    def __init__(self):
-        self._lock = threading.Lock()
-        self.calls = 0
+        task_hub_client = DurableTaskSchedulerClient(
+            host_address=self.server_address,
+            secure_channel=False,
+            taskhub="test-taskhub",
+            token_credential=credential,
+        )
 
-    def get_token(self, _scope):
-        with self._lock:
-            self.calls += 1
-            call_number = self.calls
-        time.sleep(0.02)
-        return AccessToken(f"token-{call_number}", int(time.time()) + 3600)
+        self.assertEqual(0, credential.calls, "Constructing a client must not acquire a token")
+
+        task_hub_client.get_orchestration_state("test-instance-id")
+
+        self.assertEqual(1, credential.calls, "The first request should acquire exactly one token")
+        self.assertIn("authorization", self.mock_servicer.captured_metadata)
+
+        task_hub_client.get_orchestration_state("test-instance-id")
+
+        self.assertEqual(1, credential.calls, "A cached, unexpired token should be reused")
+        self.assertEqual(2, self.mock_servicer.requests_received)
+
+    def test_worker_construction_does_not_acquire_token(self):
+        """Token acquisition is deferred from worker construction to the first request."""
+        credential = _TestTokenCredential()
+
+        DurableTaskSchedulerWorker(
+            host_address=self.server_address,
+            secure_channel=False,
+            taskhub="test-taskhub",
+            token_credential=credential,
+        )
+
+        self.assertEqual(0, credential.calls, "Constructing a worker must not acquire a token")
 
 
 class TestAccessTokenManagerThreadSafety(unittest.TestCase):
+
+    @staticmethod
+    def _get_access_token_concurrently(manager: AccessTokenManager, thread_count: int = 8) -> None:
+        threads = [threading.Thread(target=manager.get_access_token) for _ in range(thread_count)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+    def test_deferred_first_acquisition_performs_single_acquisition(self):
+        credential = _TestTokenCredential()
+        manager = AccessTokenManager(credential)
+
+        self.assertEqual(0, credential.calls, "Constructing the manager must not acquire a token")
+
+        self._get_access_token_concurrently(manager)
+
+        self.assertEqual(1, credential.calls)
+        token = manager.get_access_token()
+        self.assertIsNotNone(token)
+        self.assertEqual("token-1", token.token)  # type: ignore[union-attr]
+        self.assertEqual(1, credential.calls, "A cached, unexpired token should be reused")
+
     def test_concurrent_refresh_performs_single_refresh(self):
         credential = _TestTokenCredential()
         manager = AccessTokenManager(credential)
+        manager.get_access_token()
+        self.assertEqual(1, credential.calls)
+
         manager.expiry_time = datetime.now(timezone.utc) - timedelta(seconds=1)
 
-        threads = []
-        for _ in range(8):
-            thread = threading.Thread(target=manager.get_access_token)
-            thread.start()
-            threads.append(thread)
-
-        for thread in threads:
-            thread.join()
+        self._get_access_token_concurrently(manager)
 
         self.assertEqual(2, credential.calls)
 


### PR DESCRIPTION
## Summary

`AccessTokenManager.__init__()` acquired an Azure access token eagerly, so constructing a `DurableTaskSchedulerClient` or `DurableTaskSchedulerWorker` performed a blocking credential round trip to Entra before any RPC was made. `DTSDefaultClientInterceptorImpl.__init__()` then called `get_access_token()` immediately, so the cost was paid even for instances that were never used. `SandboxWorker` goes through the same construction path.

Token acquisition is now deferred to the first intercepted RPC:

- `AccessTokenManager.__init__()` no longer calls `credential.get_token()`; it starts with `_token = None` / `expiry_time = None`.
- `DTSDefaultClientInterceptorImpl.__init__()` no longer primes the token or the authorization header.

The existing double-checked refresh lock in `get_access_token()` is untouched, so the deferred first acquisition is still **single-flight** across threads, and refresh-before-expiry behavior is unchanged. `_intercept_call()` already upserted the authorization header on every call, so no header is missing on the first request. This mirrors what `DTSAsyncDefaultClientInterceptorImpl` already does.

## Behavior change (timing only)

Credential failures — for example an unavailable managed identity or a misconfigured `DefaultAzureCredential` — now surface from the **first request** instead of from the **constructor**. The exception type and message are unchanged; only the timing differs. This is called out in `durabletask-azuremanaged/CHANGELOG.md` under `## Unreleased`.

No public API changed: no signature changes, no renames, no removed symbols, no changed import paths. No warm-up hook was added, to avoid expanding public surface — callers that want fail-fast authentication can call `credential.get_token(...)` themselves before constructing a client or worker.

## Tests

`tests/durabletask-azuremanaged/test_durabletask_grpc_interceptor.py`:

- Added `test_client_construction_does_not_acquire_token` — asserts **zero** credential calls at client construction, **exactly one** on the first RPC, that the `authorization` header is present on that request, and that a second request reuses the cached token.
- Added `test_worker_construction_does_not_acquire_token` — asserts zero credential calls at worker construction.
- Added `test_deferred_first_acquisition_performs_single_acquisition` — 8 concurrent threads on a freshly constructed manager result in exactly **one** credential call, proving the deferred first acquisition is single-flight.
- Reworked `test_concurrent_refresh_performs_single_refresh` — the single-flight-on-expiry assertion is preserved, with the token now primed explicitly instead of relying on constructor acquisition.

All three new tests were verified to **fail** against the unfixed source and pass with the fix.

## Verification

- Provider unit tests: `pytest tests/durabletask-azuremanaged/test_durabletask_grpc_interceptor.py tests/durabletask-azuremanaged/test_sandboxes_extension.py -q` -> **45 passed** (baseline 42; +3 new).
- Core unit tests: `pytest tests/durabletask -q --ignore-glob="*_e2e.py"` -> **681 passed, 7 skipped**. Baseline on this branch had 1 failure in the timing-sensitive `test_sync_client_recreate_cooldown_prevents_immediate_repeated_recreation`, which is flaky/environmental and passes here.
- `flake8` clean on all four changed files.
- `pyright` (repo `pyrightconfig.json`, strict): **0 diagnostics** in the changed source files.
- `pymarkdown -c .pymarkdown.json scan durabletask-azuremanaged/CHANGELOG.md`: the two MD013 line-length findings are pre-existing on untouched lines; the added lines introduce none.

Scope was kept strictly to this issue — no changes related to #192 (async single-flight refresh) or #195 (SDK version lookup caching), which live in the same files.

Fixes #187
