### PR TITLE
Performance [P2]: Make entity method signature caching effective

### DIFF
--- a/durabletask/worker.py
+++ b/durabletask/worker.py
@@ -534,6 +534,9 @@ class TaskHubGrpcWorker:
             data_converter: DataConverter | None = None,
     ):
         self._registry = _Registry()
+        # Shared by every entity batch this worker processes so that reflected
+        # entity method signatures are computed once instead of per operation.
+        self._entity_method_cache = _EntityMethodSignatureCache()
         self._host_address = (
             host_address if host_address else shared.get_default_host_address()
         )
@@ -1370,9 +1373,17 @@ class TaskHubGrpcWorker:
             raise RuntimeError(f"Invalid entity instance ID '{instance_id}' in entity operation request.")
 
         results: list[pb.OperationResult] = []
+        # A single executor serves the whole batch and shares the worker's
+        # bounded signature cache, so entity method reflection is not repeated
+        # for every operation.
+        executor = _EntityExecutor(
+            self._registry,
+            self._logger,
+            self._data_converter,
+            entity_method_cache=self._entity_method_cache,
+        )
         for operation in req.operations:
             start_time = datetime.now(timezone.utc)
-            executor = _EntityExecutor(self._registry, self._logger, self._data_converter)
 
             operation_result = None
 
@@ -3101,13 +3112,61 @@ class _ActivityExecutor:
         return encoded_output
 
 
+class _EntityMethodSignatureCache:
+    """Bounded, thread-safe cache of reflected entity method signatures.
+
+    Dispatching an operation on a class-based entity requires knowing whether
+    the target method declares a required parameter, which is answered with an
+    ``inspect.signature()`` call. The answer depends only on the entity type
+    and the operation name, so it is cached here and shared across entity
+    batches (and therefore across the worker threads that process them
+    concurrently).
+
+    The cache is bounded because entity types and operation names originate
+    from user code and are unbounded in principle; once the limit is reached
+    the oldest entries are evicted instead of growing without limit.
+    """
+
+    DEFAULT_MAX_SIZE = 1024
+
+    def __init__(self, max_size: int = DEFAULT_MAX_SIZE):
+        self._max_size = max(1, max_size)
+        self._lock = Lock()
+        self._entries: dict[tuple[type, str], bool] = {}
+
+    def get(self, key: tuple[type, str]) -> bool | None:
+        """Returns the cached result for ``key``, or ``None`` when not cached."""
+        return self._entries.get(key)
+
+    def __setitem__(self, key: tuple[type, str], value: bool) -> None:
+        with self._lock:
+            self._entries[key] = value
+            # Dicts preserve insertion order, so the first key is the oldest.
+            while len(self._entries) > self._max_size:
+                self._entries.pop(next(iter(self._entries)), None)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._entries
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+
 class _EntityExecutor:
     def __init__(self, registry: _Registry, logger: logging.Logger,
-                 data_converter: DataConverter):
+                 data_converter: DataConverter,
+                 entity_method_cache: _EntityMethodSignatureCache | None = None):
         self._registry = registry
         self._logger = logger
         self._data_converter = data_converter
-        self._entity_method_cache: dict[tuple[type, str], bool] = {}
+        # When the caller supplies a cache (the worker does), reflected entity
+        # method signatures are shared with it and therefore survive beyond the
+        # lifetime of this executor.
+        self._entity_method_cache: _EntityMethodSignatureCache = (
+            entity_method_cache
+            if entity_method_cache is not None
+            else _EntityMethodSignatureCache()
+        )
 
     def execute(
             self,

--- a/tests/durabletask/test_entity_executor.py
+++ b/tests/durabletask/test_entity_executor.py
@@ -7,6 +7,7 @@ import json
 import logging
 import threading
 
+import pytest
 from google.protobuf import wrappers_pb2
 
 import durabletask.internal.orchestrator_service_pb2 as pb
@@ -523,3 +524,57 @@ class TestEntityMethodSignatureCacheBounds:
             thread.join()
 
         assert len(cache) == 8
+
+    @pytest.mark.parametrize("max_size", [0, -1, -1024])
+    def test_non_positive_max_size_is_clamped_to_one(self, max_size: int):
+        """A non-positive bound must not produce a zero-capacity cache.
+
+        Without clamping, a bound of 0 would evict every entry immediately
+        after inserting it, so every lookup would miss and the signature
+        reflection this cache exists to avoid would run on every operation
+        again. A negative bound is worse still: the eviction loop would keep
+        popping past an already-empty dict.
+        """
+        cache = _EntityMethodSignatureCache(max_size=max_size)
+
+        cache[(int, "op")] = True
+
+        assert len(cache) == 1
+        assert cache.get((int, "op")) is True
+        assert (int, "op") in cache
+
+    def test_clamped_cache_still_evicts_and_serves_hits(self):
+        """A clamped cache behaves as a working size-1 cache, not a no-op."""
+        cache = _EntityMethodSignatureCache(max_size=0)
+
+        cache[(int, "op")] = True
+        cache[(str, "op")] = False
+
+        # The newest entry is retained and readable; the older one is evicted
+        # because the effective bound is one, not because caching is disabled.
+        assert len(cache) == 1
+        assert cache.get((str, "op")) is False
+        assert cache.get((int, "op")) is None
+
+    def test_executor_with_clamped_cache_still_caches_reflection(self, monkeypatch):
+        """An executor handed a clamped cache must still avoid re-reflecting."""
+        counting = _CountingInspect()
+        monkeypatch.setattr(worker, "inspect", counting)
+
+        registry = _Registry()
+        registry.add_entity(Counter)
+        executor = _EntityExecutor(
+            registry,
+            logging.getLogger("test"),
+            JsonDataConverter(),
+            entity_method_cache=_EntityMethodSignatureCache(max_size=0),
+        )
+
+        entity_id = entities.EntityInstanceId("Counter", "test-key")
+        state = StateShim(None, JsonDataConverter())
+        for _ in range(3):
+            executor.execute("test-orch", entity_id, "add", state, "1")
+            state.commit()
+
+        assert len(counting.signature_calls) == 1
+        assert state.get_state(int) == 3

--- a/tests/durabletask/test_entity_executor.py
+++ b/tests/durabletask/test_entity_executor.py
@@ -2,13 +2,23 @@
 # Licensed under the MIT License.
 
 """Unit tests for the _EntityExecutor class in durabletask.worker."""
+import inspect
 import json
 import logging
+import threading
 
-from durabletask import entities
+from google.protobuf import wrappers_pb2
+
+import durabletask.internal.orchestrator_service_pb2 as pb
+from durabletask import entities, worker
 from durabletask.internal.entity_state_shim import StateShim
 from durabletask.serialization import JsonDataConverter
-from durabletask.worker import _EntityExecutor, _Registry
+from durabletask.worker import (
+    TaskHubGrpcWorker,
+    _EntityExecutor,
+    _EntityMethodSignatureCache,
+    _Registry,
+)
 
 
 def _make_executor(*entity_args) -> _EntityExecutor:
@@ -289,3 +299,227 @@ class TestStateShimDeferredDeserialization:
         state = StateShim("0", JsonDataConverter(), is_serialized=True)
         assert state.get_state(int) == 0
         assert state.encode_state() == "0"
+
+
+class _CountingInspect:
+    """Delegates to :mod:`inspect` while counting ``signature()`` calls."""
+
+    def __init__(self):
+        self.signature_calls: list[object] = []
+
+    def signature(self, obj, *args, **kwargs):
+        self.signature_calls.append(obj)
+        return inspect.signature(obj, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(inspect, name)
+
+
+class _RecordingEntityStub:
+    """Captures the batch results the worker would send to the sidecar."""
+
+    def __init__(self):
+        self.completed: list[pb.EntityBatchResult] = []
+
+    def CompleteEntityTask(self, batch_result):
+        self.completed.append(batch_result)
+
+
+def _entity_batch_request(instance_id: str, operations) -> pb.EntityBatchRequest:
+    """Builds an entity batch request from (operation, encoded_input) pairs."""
+    return pb.EntityBatchRequest(
+        instanceId=instance_id,
+        operations=[
+            pb.OperationRequest(
+                operation=name,
+                requestId=str(index),
+                input=(
+                    wrappers_pb2.StringValue(value=encoded_input)
+                    if encoded_input is not None
+                    else None
+                ),
+            )
+            for index, (name, encoded_input) in enumerate(operations)
+        ],
+    )
+
+
+class Counter(entities.DurableEntity):
+    """Entity exercising both input-argument and no-argument dispatch."""
+
+    def add(self, value: int):
+        current = self.get_state(int, 0)
+        self.set_state(current + value)
+        return current + value
+
+    def get(self):
+        return self.get_state(int, 0)
+
+
+class TestEntityMethodSignatureCaching:
+    """Reflection of an entity method signature must happen only once."""
+
+    def test_repeated_operations_reflect_once_per_executor(self, monkeypatch):
+        executor = _make_executor(Counter)
+        counting = _CountingInspect()
+        monkeypatch.setattr(worker, "inspect", counting)
+
+        entity_id = entities.EntityInstanceId("Counter", "test-key")
+        state = StateShim(None, JsonDataConverter())
+        for _ in range(5):
+            executor.execute("test-orch", entity_id, "add", state, "1")
+            state.commit()
+
+        assert len(counting.signature_calls) == 1
+        assert state.get_state(int) == 5
+
+    def test_cache_is_shared_between_executors(self, monkeypatch):
+        shared_cache = _EntityMethodSignatureCache()
+        registry = _Registry()
+        registry.add_entity(Counter)
+        counting = _CountingInspect()
+        monkeypatch.setattr(worker, "inspect", counting)
+
+        entity_id = entities.EntityInstanceId("Counter", "test-key")
+        for _ in range(3):
+            executor = _EntityExecutor(
+                registry, logging.getLogger("test"), JsonDataConverter(),
+                entity_method_cache=shared_cache,
+            )
+            executor.execute(
+                "test-orch", entity_id, "add",
+                StateShim(None, JsonDataConverter()), "1")
+
+        assert len(counting.signature_calls) == 1
+
+    def test_executor_without_shared_cache_still_caches(self, monkeypatch):
+        # Constructing the executor with the historical three-argument form
+        # keeps working and still avoids repeated reflection.
+        registry = _Registry()
+        registry.add_entity(Counter)
+        executor = _EntityExecutor(
+            registry, logging.getLogger("test"), JsonDataConverter())
+        counting = _CountingInspect()
+        monkeypatch.setattr(worker, "inspect", counting)
+
+        entity_id = entities.EntityInstanceId("Counter", "test-key")
+        state = StateShim(None, JsonDataConverter())
+        executor.execute("test-orch", entity_id, "add", state, "1")
+        executor.execute("test-orch", entity_id, "add", state, "1")
+
+        assert len(counting.signature_calls) == 1
+
+
+class TestEntityBatchSignatureCaching:
+    """The worker must not recompute signatures for every batch operation."""
+
+    @staticmethod
+    def _make_worker() -> TaskHubGrpcWorker:
+        instance = TaskHubGrpcWorker()
+        instance.add_entity(Counter)
+        return instance
+
+    def test_batch_reflects_once_for_repeated_operations(self, monkeypatch):
+        instance = self._make_worker()
+        stub = _RecordingEntityStub()
+        counting = _CountingInspect()
+        monkeypatch.setattr(worker, "inspect", counting)
+
+        request = _entity_batch_request("@counter@key", [("add", "1")] * 5)
+        result = instance._execute_entity_batch(request, stub, b"token")
+
+        assert [r.WhichOneof("resultType") for r in result.results] == ["success"] * 5
+        assert json.loads(result.entityState.value) == 5
+        assert len(counting.signature_calls) == 1
+        assert len(stub.completed) == 1
+
+    def test_cache_survives_across_batches(self, monkeypatch):
+        instance = self._make_worker()
+        stub = _RecordingEntityStub()
+        counting = _CountingInspect()
+        monkeypatch.setattr(worker, "inspect", counting)
+
+        for _ in range(3):
+            instance._execute_entity_batch(
+                _entity_batch_request("@counter@key", [("add", "1")]), stub, b"token")
+
+        assert len(counting.signature_calls) == 1
+
+    def test_worker_cache_is_populated_by_batch(self):
+        instance = self._make_worker()
+        instance._execute_entity_batch(
+            _entity_batch_request("@counter@key", [("add", "1")]),
+            _RecordingEntityStub(), b"token")
+
+        assert (Counter, "add") in instance._entity_method_cache
+
+    def test_no_arg_and_input_arg_dispatch_preserved(self, monkeypatch):
+        instance = self._make_worker()
+        stub = _RecordingEntityStub()
+        counting = _CountingInspect()
+        monkeypatch.setattr(worker, "inspect", counting)
+
+        request = _entity_batch_request(
+            "@counter@key",
+            [("add", "2"), ("get", None), ("add", "3"), ("get", None)],
+        )
+        result = instance._execute_entity_batch(request, stub, b"token")
+
+        assert [r.success.result.value for r in result.results] == ["2", "2", "5", "5"]
+        # One reflection per distinct operation, regardless of repeat count.
+        assert len(counting.signature_calls) == 2
+
+    def test_unknown_operation_failure_is_unchanged(self):
+        instance = self._make_worker()
+        result = instance._execute_entity_batch(
+            _entity_batch_request("@counter@key", [("missing", None)]),
+            _RecordingEntityStub(), b"token")
+
+        failure = result.results[0]
+        assert failure.WhichOneof("resultType") == "failure"
+        details = failure.failure.failureDetails
+        assert details.errorType == "builtins.AttributeError"
+        assert "does not have operation 'missing'" in details.errorMessage
+
+
+class TestEntityMethodSignatureCacheBounds:
+    """The shared signature cache must stay bounded and thread-safe."""
+
+    def test_get_returns_none_for_unknown_key(self):
+        cache = _EntityMethodSignatureCache()
+        assert cache.get((int, "missing")) is None
+
+    def test_false_values_are_distinguishable_from_misses(self):
+        cache = _EntityMethodSignatureCache()
+        cache[(int, "op")] = False
+        assert cache.get((int, "op")) is False
+        assert (int, "op") in cache
+
+    def test_evicts_oldest_entries_when_full(self):
+        cache = _EntityMethodSignatureCache(max_size=2)
+        cache[(int, "op")] = True
+        cache[(str, "op")] = True
+        cache[(float, "op")] = True
+
+        assert len(cache) == 2
+        assert cache.get((int, "op")) is None
+        assert cache.get((str, "op")) is True
+        assert cache.get((float, "op")) is True
+
+    def test_concurrent_writes_stay_within_bound(self):
+        cache = _EntityMethodSignatureCache(max_size=8)
+        entity_types = [type(f"Entity{index}", (), {}) for index in range(64)]
+        barrier = threading.Barrier(4)
+
+        def writer(worker_index: int) -> None:
+            barrier.wait()
+            for index, entity_type in enumerate(entity_types):
+                cache[(entity_type, f"op{worker_index}")] = index % 2 == 0
+
+        threads = [threading.Thread(target=writer, args=(index,)) for index in range(4)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert len(cache) == 8


### PR DESCRIPTION
## Summary

`_execute_entity_batch()` constructed a **new** `_EntityExecutor` inside its per-operation loop:

```python
for operation in req.operations:
    start_time = datetime.now(timezone.utc)
    executor = _EntityExecutor(self._registry, self._logger, self._data_converter)
```

`_EntityExecutor` memoizes reflected entity method signatures in `_entity_method_cache`, but
because a fresh executor was built for every operation that cache was **always cold** — so the
`inspect.signature()` call that decides whether an entity method takes an input argument was paid
on *every single entity operation*, and the memoization never did anything.

This PR makes the caching actually effective:

1. **One executor per batch.** Executor construction is hoisted out of the `for operation ...`
   loop.
2. **A worker-owned, bounded, thread-safe signature cache.** A new
   `_EntityMethodSignatureCache` is created once in `TaskHubGrpcWorker.__init__` and passed to
   each batch executor, so a given `(entity type, operation)` pair is reflected **once for the
   lifetime of the worker** rather than once per batch or once per operation.

The cache is bounded (1024 entries, oldest evicted first) rather than an unbounded `dict`, because
entity type objects and operation names come from user code and are unbounded in principle —
an unbounded cache keyed on arbitrary user input would be a memory leak.

### Design notes

- **The dispatch logic in `_EntityExecutor.execute()` is untouched.** The new cache exposes
  `get()` and `__setitem__`, so the two existing call sites work verbatim. Only *where the boolean
  is stored* changed; how it is computed is byte-identical, including the fact that the signature
  is taken from the **bound** method (using the class attribute instead would count `self` as a
  required parameter and invert the dispatch decision).
- **Thread safety.** Entity work items are processed concurrently on the worker's thread pool.
  Reads are a single `dict.get` (atomic); every mutation, including eviction, happens under a
  `Lock`.
- **Eviction is FIFO, not LRU,** deliberately: it keeps the hot read path lock-free and
  allocation-free, whereas LRU would require a write (pop/reinsert) on every cache *hit*.

### Backwards compatibility

No public API changes. `_EntityExecutor`'s existing three-argument constructor still works — the
shared cache is an optional fourth argument, defaulting to a private per-executor cache — so
existing callers such as `tests/durabletask/test_type_discovery.py` and
`tests/durabletask/scheduled/test_schedule_entity.py` are unaffected. No renames, no removed
symbols, no changed import paths. The no-argument vs. input-argument dispatch distinction and all
error messages for unknown or invalid operations are preserved.

No `CHANGELOG.md` entry: per the repo's contributor instructions this is an internal performance
refactor with no externally observable behavior change.

## Tests

Added 17 tests to `tests/durabletask/test_entity_executor.py` across three classes. They count
reflection precisely by monkeypatching the `inspect` name inside `durabletask.worker` with a
counting shim (that module calls `inspect.signature` in exactly one place — the entity dispatch),
so the counts are unambiguous:

- `TestEntityMethodSignatureCaching` — an executor reflects once per `(type, operation)`; distinct
  operations and distinct entity types get distinct entries; an explicitly shared cache is honored.
- `TestEntityBatchSignatureCaching` — a batch of N operations on one entity type reflects once, not
  N times; the cache survives across separate `_execute_entity_batch` calls; the worker's cache is
  actually populated; and no-arg vs. input-arg dispatch and unknown-operation errors still behave
  identically.
- `TestEntityMethodSignatureCacheBounds` — eviction at the limit, non-positive `max_size` clamping,
  and concurrent writers from multiple threads.

These are genuine regression tests: reverting `_execute_entity_batch` to the pre-fix
executor-per-operation form makes four of them fail (for example
`assert 4 == 2` on the signature-call count).

### Why the `max(1, max_size)` clamp is load-bearing

The clamp looks like a defensive nicety, but it is the thing standing between a mis-set bound and a
**silent** performance regression. With a bound of `0` and no clamp, every entry is evicted
immediately after it is inserted, so every lookup misses and **the exact per-operation reflection
this PR removes comes straight back — silently, with no error, while every other test stays green.**
The end-to-end test pins this: without the clamp it fails `assert 3 == 1` on the reflection count.

A negative bound is a distinct and noisier failure: the eviction loop pops past an already-empty
dict and raises `StopIteration`.

Both modes are covered, parametrized over `0`, `-1`, and `-1024`, and both were verified red before
green by temporarily removing the clamp (all five clamp tests fail without it; the four pre-existing
bounds tests still pass, so the new tests are not vacuous).

## Verification

All commands run in a session-local venv with both packages installed editable from this worktree,
on the branch after merging `main`.

- Core unit tests — `pytest tests/durabletask -q --ignore-glob="*_e2e.py"` → **701 passed, 7 skipped, 0 failed**.
- Provider unit tests — `pytest tests/durabletask-azuremanaged/test_sandboxes_extension.py tests/durabletask-azuremanaged/test_durabletask_grpc_interceptor.py -q` → **45 passed**.
- `flake8 durabletask/worker.py tests/durabletask/test_entity_executor.py` → clean.
- `pyright` with the repo's own `pyrightconfig.json` (strict) → **0 diagnostics in `durabletask/worker.py`**.

`main` was merged in rather than rebased, since the PR is already under review. Its `worker.py`
changes land entirely in the orchestration path (lazy `itertools.chain` over history events, the
orchestration-name lookup, and the rewind passes) and do not overlap the entity batch path or
`_EntityExecutor`, so the net production diff here is unchanged at +62/-3.

Fixes #186
