### PR TITLE
Performance [P2]: Reduce orchestration history replay allocations

### DIFF
--- a/durabletask/worker.py
+++ b/durabletask/worker.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import inspect
+import itertools
 import json
 import logging
 import os
@@ -1132,10 +1133,12 @@ class TaskHubGrpcWorker:
         if self._payload_store is not None:
             payload_helpers.deexternalize_payloads(req, self._payload_store)
 
-        # Extract parent trace context from executionStarted event
+        # Extract parent trace context from executionStarted event.
+        # Chain the two event lists lazily so that long histories are not
+        # copied just to locate the first executionStarted event.
         parent_trace_ctx = None
         orchestration_name = "<unknown>"
-        for e in list(req.pastEvents) + list(req.newEvents):
+        for e in itertools.chain(req.pastEvents, req.newEvents):
             if e.HasField("executionStarted"):
                 orchestration_name = e.executionStarted.name
                 if e.executionStarted.HasField("parentTraceContext"):
@@ -2132,10 +2135,12 @@ class _OrchestrationExecutor:
             old_events: Sequence[pb.HistoryEvent],
             new_events: Sequence[pb.HistoryEvent],
     ) -> ExecutionResults:
-        orchestration_name = "<unknown>"
-        orchestration_started_events = [e for e in old_events if e.HasField("executionStarted")]
-        if len(orchestration_started_events) >= 1:
-            orchestration_name = orchestration_started_events[0].executionStarted.name
+        # Only the first executionStarted event is needed, so stop at the
+        # first match instead of materializing every matching event.
+        orchestration_name = next(
+            (e.executionStarted.name for e in old_events if e.HasField("executionStarted")),
+            "<unknown>",
+        )
         self._orchestration_name = orchestration_name
 
         self._logger.debug(
@@ -2286,21 +2291,22 @@ class _OrchestrationExecutor:
 
         rewind_event: pb.ExecutionRewoundEvent = new_events[1].executionRewound
 
-        all_events = list(old_events) + list(new_events)
         # Generate a new execution ID for the rewound execution.
         new_execution_id = uuid.uuid4().hex
 
         # First pass: collect the task-scheduled IDs that correspond to
         # failed activities so we can remove the matching taskScheduled
-        # events in the second pass.
+        # events in the second pass.  Both arguments are sequences, so each
+        # pass chains them lazily (old events first, then new events)
+        # instead of copying the whole history into a combined list.
         failed_task_ids: set[int] = set()
-        for event in all_events:
+        for event in itertools.chain(old_events, new_events):
             if event.HasField("taskFailed"):
                 failed_task_ids.add(event.taskFailed.taskScheduledId)
 
         # Second pass: build the clean history.
         clean_history: list[pb.HistoryEvent] = []
-        for event in all_events:
+        for event in itertools.chain(old_events, new_events):
             if event.HasField("taskFailed"):
                 continue
             if event.HasField("taskScheduled") and event.eventId in failed_task_ids:

--- a/tests/durabletask/test_orchestration_executor.py
+++ b/tests/durabletask/test_orchestration_executor.py
@@ -93,6 +93,49 @@ def test_orchestrator_parent_instance_id_none_for_top_level():
     assert observed["parent"] is None
 
 
+def test_orchestration_name_resolved_from_committed_history():
+    """The orchestration name is taken from the first executionStarted event in old events."""
+
+    def dummy_activity(ctx, _):
+        pass
+
+    def orchestrator(ctx: task.OrchestrationContext, _):
+        result = yield ctx.call_activity(dummy_activity, input=None)
+        return result
+
+    registry = worker._Registry()
+    name = registry.add_orchestrator(orchestrator)
+
+    # executionStarted is not the first event, so the whole prefix of the
+    # committed history has to be scanned before the name is found.
+    old_events = [
+        helpers.new_orchestrator_started_event(),
+        helpers.new_execution_started_event(name, TEST_INSTANCE_ID, encoded_input=None),
+        helpers.new_task_scheduled_event(1, task.get_name(dummy_activity))]
+    new_events = [helpers.new_task_completed_event(1, json.dumps("done!"))]
+
+    executor = worker._OrchestrationExecutor(registry, TEST_LOGGER, JsonDataConverter())
+    executor.execute(TEST_INSTANCE_ID, old_events, new_events)
+
+    assert executor._orchestration_name == name
+
+
+def test_orchestration_name_unknown_without_committed_history():
+    """The orchestration name falls back to '<unknown>' when old events carry no executionStarted."""
+
+    def orchestrator(ctx: task.OrchestrationContext, _):
+        return "done"
+
+    registry = worker._Registry()
+    name = registry.add_orchestrator(orchestrator)
+
+    new_events = [helpers.new_execution_started_event(name, TEST_INSTANCE_ID, encoded_input=None)]
+    executor = worker._OrchestrationExecutor(registry, TEST_LOGGER, JsonDataConverter())
+    executor.execute(TEST_INSTANCE_ID, [], new_events)
+
+    assert executor._orchestration_name == "<unknown>"
+
+
 def test_complete_orchestration_actions():
     """Tests the actions output for a completed orchestration"""
 


### PR DESCRIPTION
## Summary

Long orchestration histories were copied and rescanned several times per work item, before and during replay. Each of these allocated throwaway lists sized by the full history, which is pure GC pressure and cache churn on every single work item. This PR removes those copies without changing any behavior.

### Changes

**1. `TaskHubGrpcWorker._execute_orchestrator()`**

Built `list(req.pastEvents) + list(req.newEvents)` — three throwaway lists sized by the entire history — purely to locate the first `executionStarted` event and then `break`. Now iterates `itertools.chain(req.pastEvents, req.newEvents)`, which allocates a constant-size iterator instead. Iteration order (past events, then new events) and the `break` on first match are unchanged.

**2. `_OrchestrationExecutor.execute()`**

Materialized *every* `executionStarted` event in the committed history via a list comprehension, then read only element `[0]`:

```python
orchestration_started_events = [e for e in old_events if e.HasField("executionStarted")]
if len(orchestration_started_events) >= 1:
    orchestration_name = orchestration_started_events[0].executionStarted.name
```

Replaced with `next(<generator>, "<unknown>")`, which short-circuits at the first match instead of scanning and collecting the whole history. The resolved name is identical in both branches: first match when one exists, `"<unknown>"` otherwise.

**3. `_OrchestrationExecutor._build_rewind_result()`**

Built a combined `all_events = list(old_events) + list(new_events)` to feed its two passes. Both parameters are already typed `Sequence[pb.HistoryEvent]` (and the function already relies on that via `len()`/indexing), so each pass now chains them lazily with its own fresh iterator. Order is unchanged (old events first, then new events), and the first pass fully completes before the second begins — no generator-exhaustion hazard.

### Deliberately not changed

The rewind detection in `execute()` already short-circuits correctly:

```python
has_rewind_in_new = any(e.HasField("executionRewound") for e in new_events)
if has_rewind_in_new and any(e.HasField("executionCompleted") for e in old_events):
```

Both are lazy generators, and the `and` means `old_events` is only scanned when a rewind is actually in flight. Fusing the `executionCompleted` scan into the `executionStarted` scan — as the issue's proposed solution hints at — would force a full O(N) walk of the committed history on *every* normal work item, making the common path measurably worse. Left as-is on purpose.

### Compatibility

No public API signature changes, no renames, no removed symbols, no changed import paths. Replay order, rewind handling, non-determinism detection, log messages, and exception types/messages are all preserved. This is an allocation-only change with no observable behavior difference, so per the repo's changelog policy it does not get a `CHANGELOG.md` entry.

## Tests

Added two regression tests in `tests/durabletask/test_orchestration_executor.py` covering both branches of the orchestration-name lookup, which previously had no direct coverage:

- `test_orchestration_name_resolved_from_committed_history` — name is taken from the first `executionStarted` event when it is not the first event in the committed history.
- `test_orchestration_name_unknown_without_committed_history` — falls back to `<unknown>` when the committed history carries no `executionStarted` event.

## Verification

All run against a session-local venv with both packages installed editable from this worktree.

| Check | Baseline (before) | After |
| --- | --- | --- |
| `pytest tests/durabletask -q --ignore-glob="*_e2e.py"` | 680 passed, 7 skipped, 1 failed | **683 passed, 7 skipped, 0 failed** |
| `pytest tests/durabletask-azuremanaged/{test_sandboxes_extension,test_durabletask_grpc_interceptor,test_azuremanaged_grpc_resiliency}.py` | — | **45 passed** |
| `flake8 durabletask/worker.py tests/durabletask/test_orchestration_executor.py` | — | **clean** |
| `pyright durabletask/worker.py` | 0 errors | **0 errors** |

Notes on the baseline:

- The single baseline failure was `test_client.py::test_sync_client_recreate_cooldown_prevents_immediate_repeated_recreation`, a timing-sensitive test unrelated to this change; it passes after the change too.
- `tests/durabletask/test_orchestration_executor.py` (171 tests incl. the executor and tracing suites) and `tests/durabletask/test_build_rewind_result.py` (the 13 rewind tests) pass in full — these are the primary guards for replay correctness and rewind behavior.
- `pyright` reports 0 errors on `durabletask/worker.py` both before and after. The new test diagnostics are the same `reportPrivateUsage` / `reportUnknown*` kinds the test file already produces 433 times, matching the established convention in `test_build_rewind_result.py`.
- The remaining `tests/durabletask-azuremanaged` files (`test_dts_activity_sequence.py`, `test_dts_batch_actions.py`, `entities/test_dts_entity_failure_handling.py`) require a live Durable Task Scheduler endpoint and fail identically on a clean baseline in this environment.

Fixes #185
