### PR TITLE
Performance [P3]: Lazily load sandbox runtime API exports

### DIFF
--- a/durabletask-azuremanaged/CHANGELOG.md
+++ b/durabletask-azuremanaged/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- Importing `durabletask.azuremanaged.preview.sandboxes` no longer loads the sandbox worker
+  runtime or `azure-identity` up front. The package's public names are now resolved on first
+  use, which roughly halves import cost for callers that only declare sandbox worker profiles
+  or use the sandbox client. Exported names, `__all__`, and import paths are unchanged.
 - `FailureDetails.error_type` now carries the fully-qualified type name (e.g. `durabletask.task.TaskFailedError`) instead of the bare class name, and the new `FailureDetails.is_caused_by()` helper is available (both inherited from durabletask). See the core `durabletask` changelog for details, including the breaking-change notes.
 
 ## v1.8.0

--- a/durabletask-azuremanaged/durabletask/azuremanaged/preview/sandboxes/__init__.py
+++ b/durabletask-azuremanaged/durabletask/azuremanaged/preview/sandboxes/__init__.py
@@ -13,14 +13,22 @@ Usage::
         SandboxWorker,
         SandboxActivitiesClient,
     )
+
+The exports below are resolved lazily on first attribute access, so importing
+this package does not load the sandbox worker runtime (and its Azure Identity
+and gRPC dependencies) unless those APIs are actually used.
 """
 
-from durabletask.azuremanaged.preview.sandboxes.client import SandboxActivitiesClient
-from durabletask.azuremanaged.preview.sandboxes.helpers import SandboxActivity
-from durabletask.azuremanaged.preview.sandboxes.worker_profiles import SandboxWorkerProfile
-from durabletask.azuremanaged.preview.sandboxes.worker_profiles import SandboxWorkerProfileOptions
-from durabletask.azuremanaged.preview.sandboxes.worker_profiles import sandbox_worker_profile
-from durabletask.azuremanaged.preview.sandboxes.worker import SandboxWorker
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from durabletask.azuremanaged.preview.sandboxes.client import SandboxActivitiesClient
+    from durabletask.azuremanaged.preview.sandboxes.helpers import SandboxActivity
+    from durabletask.azuremanaged.preview.sandboxes.worker_profiles import SandboxWorkerProfile
+    from durabletask.azuremanaged.preview.sandboxes.worker_profiles import SandboxWorkerProfileOptions
+    from durabletask.azuremanaged.preview.sandboxes.worker_profiles import sandbox_worker_profile
+    from durabletask.azuremanaged.preview.sandboxes.worker import SandboxWorker
 
 __all__ = [
     "SandboxWorker",
@@ -30,3 +38,43 @@ __all__ = [
     "SandboxActivitiesClient",
     "sandbox_worker_profile",
 ]
+
+# Public export name -> submodule of this package that defines it.
+_LAZY_EXPORTS: dict[str, str] = {
+    "SandboxWorker": "worker",
+    "SandboxActivity": "helpers",
+    "SandboxWorkerProfile": "worker_profiles",
+    "SandboxWorkerProfileOptions": "worker_profiles",
+    "SandboxActivitiesClient": "client",
+    "sandbox_worker_profile": "worker_profiles",
+}
+
+# Submodules that eager imports previously bound as attributes of this package.
+# They remain reachable through attribute access without an explicit import.
+_LAZY_SUBMODULES: frozenset[str] = frozenset({
+    "client",
+    "helpers",
+    "profile_builder",
+    "transport",
+    "worker",
+    "worker_messages",
+    "worker_profiles",
+})
+
+
+def __getattr__(name: str) -> Any:
+    """Import public sandbox exports on first access (PEP 562)."""
+    submodule = _LAZY_EXPORTS.get(name)
+    if submodule is not None:
+        value = getattr(import_module(f".{submodule}", __name__), name)
+    elif name in _LAZY_SUBMODULES:
+        value = import_module(f".{name}", __name__)
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__) | _LAZY_SUBMODULES)

--- a/tests/durabletask-azuremanaged/test_sandboxes_extension.py
+++ b/tests/durabletask-azuremanaged/test_sandboxes_extension.py
@@ -138,12 +138,24 @@ assert "_LAZY_EXPORTS" not in globals()
 """
 
 
+_ISOLATED_PROBE_TIMEOUT_SECONDS = 60
+
+
 def _run_isolated(source: str) -> None:
-    result = subprocess.run(
-        [sys.executable, "-c", source],
-        capture_output=True,
-        text=True,
-        check=False)
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", source],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_ISOLATED_PROBE_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired as exc:
+        pytest.fail(
+            f"isolated import probe did not complete within "
+            f"{_ISOLATED_PROBE_TIMEOUT_SECONDS}s and was terminated. "
+            f"This usually means the import deadlocked.\n"
+            f"stdout: {exc.stdout or ''}\n"
+            f"stderr: {exc.stderr or ''}")
     assert result.returncode == 0, result.stdout + result.stderr
 
 

--- a/tests/durabletask-azuremanaged/test_sandboxes_extension.py
+++ b/tests/durabletask-azuremanaged/test_sandboxes_extension.py
@@ -2,8 +2,11 @@
 # Licensed under the MIT License.
 
 import inspect
+import subprocess
+import sys
 
 import grpc
+import pytest
 from azure.core.credentials import AccessToken
 
 import durabletask.azuremanaged.preview.sandboxes as sandbox
@@ -63,6 +66,101 @@ def test_public_sandbox_package_exports_customer_entrypoints_only() -> None:
     assert not hasattr(sandbox.SandboxActivitiesClient, f"remove_{legacy_prefix}_activity_worker_profile")
     assert not hasattr(sandbox.SandboxActivitiesClient, f"connect_{legacy_prefix}_activity_worker")
     assert not hasattr(SandboxWorker, f"_configure_{legacy_prefix}_activity_filters")
+
+
+# Runs in a subprocess because this test module imports the sandbox worker at
+# module scope, which would otherwise hide the lazy-import behavior.
+_LAZY_EXPORT_PROBE = """
+import sys
+
+import durabletask.azuremanaged.preview.sandboxes as sandbox
+
+eager = [
+    name
+    for name in (
+        "durabletask.azuremanaged.preview.sandboxes.client",
+        "durabletask.azuremanaged.preview.sandboxes.transport",
+        "durabletask.azuremanaged.preview.sandboxes.worker",
+        "azure.identity",
+    )
+    if name in sys.modules
+]
+assert not eager, f"sandbox package eagerly imported: {eager}"
+
+expected = [
+    "SandboxWorker",
+    "SandboxActivity",
+    "SandboxWorkerProfile",
+    "SandboxWorkerProfileOptions",
+    "SandboxActivitiesClient",
+    "sandbox_worker_profile",
+]
+assert sandbox.__all__ == expected, sandbox.__all__
+
+listing = dir(sandbox)
+assert not [name for name in expected if name not in listing], listing
+assert not [name for name in ("client", "helpers", "worker", "worker_profiles") if name not in listing], listing
+
+from durabletask.azuremanaged.preview.sandboxes.client import SandboxActivitiesClient
+from durabletask.azuremanaged.preview.sandboxes.helpers import SandboxActivity
+from durabletask.azuremanaged.preview.sandboxes.worker import SandboxWorker
+from durabletask.azuremanaged.preview.sandboxes.worker_profiles import SandboxWorkerProfile
+from durabletask.azuremanaged.preview.sandboxes.worker_profiles import SandboxWorkerProfileOptions
+from durabletask.azuremanaged.preview.sandboxes.worker_profiles import sandbox_worker_profile
+
+assert sandbox.SandboxWorker is SandboxWorker
+assert sandbox.SandboxActivity is SandboxActivity
+assert sandbox.SandboxWorkerProfile is SandboxWorkerProfile
+assert sandbox.SandboxWorkerProfileOptions is SandboxWorkerProfileOptions
+assert sandbox.SandboxActivitiesClient is SandboxActivitiesClient
+assert sandbox.sandbox_worker_profile is sandbox_worker_profile
+
+# Submodules stay reachable as package attributes, as they were while the
+# package imported them eagerly.
+assert sandbox.worker is sys.modules["durabletask.azuremanaged.preview.sandboxes.worker"]
+assert sandbox.helpers is sys.modules["durabletask.azuremanaged.preview.sandboxes.helpers"]
+"""
+
+
+_STAR_IMPORT_PROBE = """
+from durabletask.azuremanaged.preview.sandboxes import *  # noqa: F403
+
+import durabletask.azuremanaged.preview.sandboxes as sandbox
+
+star_names = {name: value for name, value in globals().items() if not name.startswith("_")}
+for name in sandbox.__all__:
+    assert name in star_names, f"missing star export: {name}"
+    assert star_names[name] is getattr(sandbox, name), name
+
+# __all__ still gates the star import, so lazy-import plumbing stays private.
+assert "import_module" not in star_names
+assert "_LAZY_EXPORTS" not in globals()
+"""
+
+
+def _run_isolated(source: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", source],
+        capture_output=True,
+        text=True,
+        check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_sandbox_package_defers_worker_runtime_imports() -> None:
+    _run_isolated(_LAZY_EXPORT_PROBE)
+
+
+def test_sandbox_package_star_import_matches_all() -> None:
+    _run_isolated(_STAR_IMPORT_PROBE)
+
+
+def test_sandbox_package_raises_attribute_error_for_unknown_attributes() -> None:
+    with pytest.raises(AttributeError, match="has no attribute 'NotARealSandboxExport'"):
+        getattr(sandbox, "NotARealSandboxExport")
+
+    assert not hasattr(sandbox, "NotARealSandboxExport")
+    assert all(hasattr(sandbox, name) for name in sandbox.__all__)
 
 
 def _sandbox_image(


### PR DESCRIPTION
## Summary

Importing `durabletask.azuremanaged.preview.sandboxes` eagerly imported both the sandbox
client and the sandbox worker. The worker module pulls in `ManagedIdentityCredential` from
`azure-identity` plus the core worker graph, so merely touching the sandboxes namespace — even
to declare a worker profile or reference a type — paid that entire cost at process startup.

This replaces the eager re-exports in the package initializer with PEP 562 lazy exports: a
module-level `__getattr__` resolves each public name from its defining submodule on first
access and caches it in the module globals. `TYPE_CHECKING` imports keep type checkers, IDEs,
and `pyright --strict` fully aware of the names.

Backwards compatibility is preserved exactly:

- Every exported name and its import path is unchanged.
- `__all__` is byte-for-byte identical, so `from ... import *` still exports the same six names.
- `dir()` still lists the public names (via a module-level `__dir__`).
- Submodules (`client`, `helpers`, `worker`, `worker_profiles`, ...) remain reachable as package
  attributes, matching the attribute binding the eager imports used to produce as a side effect.
- Unknown attributes still raise a normal `AttributeError`.

## Before / after

Measured on the same machine with `durabletask` and `durabletask.azuremanaged` installed
editable, median of 9 runs each, `HEAD~1` vs `HEAD`:

| Metric | Before (eager) | After (lazy) | Change |
| --- | --- | --- | --- |
| `-X importtime` cumulative for `durabletask.azuremanaged.preview.sandboxes` | 965.7 ms | 376.0 ms | **-61.1%** |
| Wall clock, full `python -c "import ...sandboxes"` process | 1144.1 ms | 532.5 ms | **-53.5%** |
| `len(sys.modules)` after import | 548 | 296 | **-252 modules** |

Raw `-X importtime` tail lines:

```text
before: import time:       852 |    965731 | durabletask.azuremanaged.preview.sandboxes
after:  import time:       845 |    375998 | durabletask.azuremanaged.preview.sandboxes
```

`azure.identity` alone accounts for ~890 ms of cumulative import time on this machine, and it is
no longer loaded unless `SandboxWorker` is actually used:

```text
before: worker loaded True  | azure.identity loaded True
after:  worker loaded False | azure.identity loaded False
```

### Interaction with #196

#196 makes the analogous lazy-export change to the core `durabletask/__init__.py`. Because the
sandboxes package is reached *through* `durabletask`, there are two independent doors to the
worker graph, and closing only one leaves the other open. Measured here as a full 2x2 on
`import durabletask.azuremanaged.preview.sandboxes` — module counts are deterministic, times are
the median of 7 runs of the summed `-X importtime` self-times (which include the ~87 ms
interpreter floor):

| Configuration | Modules | Median import time |
| --- | --- | --- |
| Neither (`main`) | 548 | 1079.9 ms |
| #196 alone | 548 — no change | 1037.6 ms |
| **#197 alone (this PR)** | **296** | **452.7 ms** |
| Both | 84 | 92.6 ms |

Two honest conclusions from that table:

- **#196 alone does nothing for this import path** (548 -> 548). The eager sandbox worker import
  removed by this PR was pulling the core worker graph in directly, bypassing the core
  initializer's laziness entirely. This PR is the load-bearing change for the sandboxes path.
- The 296 modules remaining after this PR are `grpc`/`protobuf` and friends, still pulled in by
  the parent `durabletask` package. That is #196's scope and is deliberately untouched here.
  With both changes landed the import drops to 84 modules — only 6 above the bare-interpreter
  floor of 78, i.e. from 470 modules of overhead down to 6.

The two PRs are therefore complementary rather than additive, and they touch disjoint files
(verified: no path overlap between the branches). These figures were reproduced independently in
this worktree; the module counts match the #196 author's measurements exactly.

## Verification

- **New tests** in `tests/durabletask-azuremanaged/test_sandboxes_extension.py`. Because that
  module imports the sandbox worker at module scope, the lazy-import assertions run in a
  subprocess:
  - `test_sandbox_package_defers_worker_runtime_imports` — asserts `...sandboxes.worker`,
    `...sandboxes.client`, `...sandboxes.transport`, and `azure.identity` are absent from
    `sys.modules` after importing the package, then asserts `__all__`, `dir()`, that every
    exported name resolves to the same object as a direct import, and that submodule attributes
    still work.
  - `test_sandbox_package_star_import_matches_all` — asserts `from ... import *` yields exactly
    the `__all__` names and does not leak the lazy-import plumbing.
  - `test_sandbox_package_raises_attribute_error_for_unknown_attributes` — asserts a proper
    `AttributeError` and correct `hasattr` behavior.
  - Confirmed these fail against the pre-change initializer (the lazy-import probe reports
    `client`, `transport`, `worker`, and `azure.identity` as eagerly imported).
- **Provider unit tests**: `test_sandboxes_extension.py` + `test_durabletask_grpc_interceptor.py`
  — 45 passed (42 before this change, plus the 3 new tests).
- **Core unit tests**: `pytest tests/durabletask --ignore-glob="*_e2e.py"` — 681 passed,
  7 skipped, no regressions against the recorded baseline.
- **flake8**: clean on both changed Python files. The `TYPE_CHECKING` imports are resolved
  properly rather than suppressed — pyflakes treats names listed in `__all__` as used, so no
  `noqa` was needed.
- **pyright** (repo `pyrightconfig.json`, strict): zero errors in the changed file and zero
  anywhere under `durabletask-azuremanaged/durabletask`.
- **pymarkdownlnt**: the changelog addition introduces no new findings.
- **autopep8**: `--diff` is empty for both changed files.

Fixes #197