### PR TITLE
Performance [P2]: Avoid eager worker imports from Azure managed package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ ADDED
 
 CHANGED
 
+- Importing `durabletask` no longer eagerly imports the worker implementation and its dependencies (gRPC, protobuf, entities, serialization, OpenTelemetry). The public names re-exported from the package — `ActivityWorkItemFilter`, `ConcurrencyOptions`, `EntityWorkItemFilter`, `GrpcChannelOptions`, `GrpcRetryPolicyOptions`, `LargePayloadStorageOptions`, `OrchestrationWorkItemFilter`, `PayloadStore`, `VersioningOptions`, and `WorkItemFilters` — are now resolved on first use, so `import durabletask` is substantially faster and loads far fewer modules. This measurably reduces cold-start time for client-only applications, including those using `durabletask.azuremanaged`, which shares the same `durabletask` namespace. All existing import paths, `__all__`, `dir()`, and star-imports behave exactly as before.
 - **Breaking:** `FailureDetails.error_type` — and the `errorType` value sent over the wire — is now the fully-qualified type name (`module.ClassName`, e.g. `builtins.ValueError`, `durabletask.task.TaskFailedError`) instead of the bare class name, matching the .NET and Java SDKs. Code that compared `error_type` against a bare name (for example `== "ValueError"`) must be updated to the qualified name or, preferably, switched to `FailureDetails.is_caused_by()`. Because this value is persisted and crosses the orchestration boundary, failures produced by older workers may still carry a bare name; `is_caused_by()` accepts both.
 
 ## v1.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,15 @@ ADDED
 CHANGED
 
 - Importing `durabletask` no longer eagerly imports the worker implementation and its
-  dependencies (gRPC, protobuf, entities, serialization, OpenTelemetry). The public names
-  re-exported from the package — `ActivityWorkItemFilter`, `ConcurrencyOptions`,
-  `EntityWorkItemFilter`, `GrpcChannelOptions`, `GrpcRetryPolicyOptions`,
-  `LargePayloadStorageOptions`, `OrchestrationWorkItemFilter`, `PayloadStore`,
-  `VersioningOptions`, and `WorkItemFilters` — are now resolved on first use, so
-  `import durabletask` is substantially faster and loads far fewer modules. This
-  measurably reduces cold-start time for client-only applications, including those using
-  `durabletask.azuremanaged`, which shares the same `durabletask` namespace. All existing
-  import paths, `__all__`, `dir()`, and star-imports behave exactly as before.
+dependencies (gRPC, protobuf, entities, serialization, OpenTelemetry). The public names
+re-exported from the package — `ActivityWorkItemFilter`, `ConcurrencyOptions`,
+`EntityWorkItemFilter`, `GrpcChannelOptions`, `GrpcRetryPolicyOptions`,
+`LargePayloadStorageOptions`, `OrchestrationWorkItemFilter`, `PayloadStore`,
+`VersioningOptions`, and `WorkItemFilters` — are now resolved on first use, so
+`import durabletask` is substantially faster and loads far fewer modules. This
+measurably reduces cold-start time for client-only applications, including those using
+`durabletask.azuremanaged`, which shares the same `durabletask` namespace. All existing
+import paths, `__all__`, `dir()`, and star-imports behave exactly as before.
 - **Breaking:** `FailureDetails.error_type` — and the `errorType` value sent over the wire — is now the fully-qualified type name (`module.ClassName`, e.g. `builtins.ValueError`, `durabletask.task.TaskFailedError`) instead of the bare class name, matching the .NET and Java SDKs. Code that compared `error_type` against a bare name (for example `== "ValueError"`) must be updated to the qualified name or, preferably, switched to `FailureDetails.is_caused_by()`. Because this value is persisted and crosses the orchestration boundary, failures produced by older workers may still carry a bare name; `is_caused_by()` accepts both.
 
 ## v1.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,15 @@ ADDED
 CHANGED
 
 - Importing `durabletask` no longer eagerly imports the worker implementation and its
-dependencies (gRPC, protobuf, entities, serialization, OpenTelemetry). The public names
-re-exported from the package — `ActivityWorkItemFilter`, `ConcurrencyOptions`,
-`EntityWorkItemFilter`, `GrpcChannelOptions`, `GrpcRetryPolicyOptions`,
-`LargePayloadStorageOptions`, `OrchestrationWorkItemFilter`, `PayloadStore`,
-`VersioningOptions`, and `WorkItemFilters` — are now resolved on first use, so
-`import durabletask` is substantially faster and loads far fewer modules. This
-measurably reduces cold-start time for client-only applications, including those using
-`durabletask.azuremanaged`, which shares the same `durabletask` namespace. All existing
-import paths, `__all__`, `dir()`, and star-imports behave exactly as before.
+  dependencies (gRPC, protobuf, entities, serialization, OpenTelemetry). The public names
+  re-exported from the package — `ActivityWorkItemFilter`, `ConcurrencyOptions`,
+  `EntityWorkItemFilter`, `GrpcChannelOptions`, `GrpcRetryPolicyOptions`,
+  `LargePayloadStorageOptions`, `OrchestrationWorkItemFilter`, `PayloadStore`,
+  `VersioningOptions`, and `WorkItemFilters` — are now resolved on first use, so
+  `import durabletask` is substantially faster and loads far fewer modules. This
+  measurably reduces cold-start time for client-only applications, including those using
+  `durabletask.azuremanaged`, which shares the same `durabletask` namespace. All existing
+  import paths, `__all__`, `dir()`, and star-imports behave exactly as before.
 - **Breaking:** `FailureDetails.error_type` — and the `errorType` value sent over the wire — is now the fully-qualified type name (`module.ClassName`, e.g. `builtins.ValueError`, `durabletask.task.TaskFailedError`) instead of the bare class name, matching the .NET and Java SDKs. Code that compared `error_type` against a bare name (for example `== "ValueError"`) must be updated to the qualified name or, preferably, switched to `FailureDetails.is_caused_by()`. Because this value is persisted and crosses the orchestration boundary, failures produced by older workers may still carry a bare name; `is_caused_by()` accepts both.
 
 ## v1.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,16 @@ ADDED
 
 CHANGED
 
-- Importing `durabletask` no longer eagerly imports the worker implementation and its dependencies (gRPC, protobuf, entities, serialization, OpenTelemetry). The public names re-exported from the package — `ActivityWorkItemFilter`, `ConcurrencyOptions`, `EntityWorkItemFilter`, `GrpcChannelOptions`, `GrpcRetryPolicyOptions`, `LargePayloadStorageOptions`, `OrchestrationWorkItemFilter`, `PayloadStore`, `VersioningOptions`, and `WorkItemFilters` — are now resolved on first use, so `import durabletask` is substantially faster and loads far fewer modules. This measurably reduces cold-start time for client-only applications, including those using `durabletask.azuremanaged`, which shares the same `durabletask` namespace. All existing import paths, `__all__`, `dir()`, and star-imports behave exactly as before.
+- Importing `durabletask` no longer eagerly imports the worker implementation and its
+dependencies (gRPC, protobuf, entities, serialization, OpenTelemetry). The public names
+re-exported from the package — `ActivityWorkItemFilter`, `ConcurrencyOptions`,
+`EntityWorkItemFilter`, `GrpcChannelOptions`, `GrpcRetryPolicyOptions`,
+`LargePayloadStorageOptions`, `OrchestrationWorkItemFilter`, `PayloadStore`,
+`VersioningOptions`, and `WorkItemFilters` — are now resolved on first use, so
+`import durabletask` is substantially faster and loads far fewer modules. This
+measurably reduces cold-start time for client-only applications, including those using
+`durabletask.azuremanaged`, which shares the same `durabletask` namespace. All existing
+import paths, `__all__`, `dir()`, and star-imports behave exactly as before.
 - **Breaking:** `FailureDetails.error_type` — and the `errorType` value sent over the wire — is now the fully-qualified type name (`module.ClassName`, e.g. `builtins.ValueError`, `durabletask.task.TaskFailedError`) instead of the bare class name, matching the .NET and Java SDKs. Code that compared `error_type` against a bare name (for example `== "ValueError"`) must be updated to the qualified name or, preferably, switched to `FailureDetails.is_caused_by()`. Because this value is persisted and crosses the orchestration boundary, failures produced by older workers may still carry a bare name; `is_caused_by()` accepts both.
 
 ## v1.8.0

--- a/durabletask/__init__.py
+++ b/durabletask/__init__.py
@@ -3,16 +3,19 @@
 
 """Durable Task SDK for Python"""
 
-from durabletask.grpc_options import GrpcChannelOptions, GrpcRetryPolicyOptions
-from durabletask.payload.store import LargePayloadStorageOptions, PayloadStore
-from durabletask.worker import (
-    ActivityWorkItemFilter,
-    ConcurrencyOptions,
-    EntityWorkItemFilter,
-    OrchestrationWorkItemFilter,
-    VersioningOptions,
-    WorkItemFilters,
-)
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from durabletask.grpc_options import GrpcChannelOptions, GrpcRetryPolicyOptions
+    from durabletask.payload.store import LargePayloadStorageOptions, PayloadStore
+    from durabletask.worker import (
+        ActivityWorkItemFilter,
+        ConcurrencyOptions,
+        EntityWorkItemFilter,
+        OrchestrationWorkItemFilter,
+        VersioningOptions,
+        WorkItemFilters,
+    )
 
 __all__ = [
     "ActivityWorkItemFilter",
@@ -28,3 +31,41 @@ __all__ = [
 ]
 
 PACKAGE_NAME = "durabletask"
+
+# Public names are resolved lazily so that merely importing the ``durabletask``
+# package - which also happens implicitly when importing anything from the
+# ``durabletask.azuremanaged`` distribution, since both share this namespace -
+# does not pull in the worker dependency graph (gRPC, protobuf, entities,
+# serialization, OpenTelemetry). Client-only applications would otherwise pay
+# that cost at process startup.
+_LAZY_EXPORTS: dict[str, str] = {
+    "ActivityWorkItemFilter": "durabletask.worker",
+    "ConcurrencyOptions": "durabletask.worker",
+    "EntityWorkItemFilter": "durabletask.worker",
+    "GrpcChannelOptions": "durabletask.grpc_options",
+    "GrpcRetryPolicyOptions": "durabletask.grpc_options",
+    "LargePayloadStorageOptions": "durabletask.payload.store",
+    "OrchestrationWorkItemFilter": "durabletask.worker",
+    "PayloadStore": "durabletask.payload.store",
+    "VersioningOptions": "durabletask.worker",
+    "WorkItemFilters": "durabletask.worker",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Import and return a lazily exported public name (PEP 562)."""
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    from importlib import import_module
+
+    value = getattr(import_module(module_name), name)
+    # Cache on the module so subsequent lookups bypass this hook entirely.
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Include lazily exported names that have not been resolved yet."""
+    return sorted(set(globals()) | set(__all__))

--- a/durabletask/__init__.py
+++ b/durabletask/__init__.py
@@ -51,16 +51,35 @@ _LAZY_EXPORTS: dict[str, str] = {
     "WorkItemFilters": "durabletask.worker",
 }
 
+# Submodules that the previous eager imports bound as attributes of this package
+# as a side effect. Attribute access keeps them reachable without an explicit
+# ``import durabletask.<name>``, exactly as before, but they are now imported
+# only when actually touched. This list mirrors the old surface and must not be
+# extended: ``durabletask.client``, for instance, was never bound this way.
+_LAZY_SUBMODULES: frozenset[str] = frozenset({
+    "entities",
+    "grpc_options",
+    "internal",
+    "payload",
+    "serialization",
+    "task",
+    "worker",
+})
+
 
 def __getattr__(name: str) -> Any:
-    """Import and return a lazily exported public name (PEP 562)."""
+    """Import and return a lazily exported public name or submodule (PEP 562)."""
     module_name = _LAZY_EXPORTS.get(name)
-    if module_name is None:
+    if module_name is None and name not in _LAZY_SUBMODULES:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
     from importlib import import_module
 
-    value = getattr(import_module(module_name), name)
+    if module_name is not None:
+        value = getattr(import_module(module_name), name)
+    else:
+        value = import_module(f".{name}", __name__)
+
     # Cache on the module so subsequent lookups bypass this hook entirely.
     globals()[name] = value
     return value
@@ -68,4 +87,4 @@ def __getattr__(name: str) -> Any:
 
 def __dir__() -> list[str]:
     """Include lazily exported names that have not been resolved yet."""
-    return sorted(set(globals()) | set(__all__))
+    return sorted(set(globals()) | set(__all__) | _LAZY_SUBMODULES)

--- a/tests/durabletask/test_lazy_exports.py
+++ b/tests/durabletask/test_lazy_exports.py
@@ -115,6 +115,9 @@ def test_importing_package_does_not_import_grpc_or_protobuf():
 
 def test_importing_azuremanaged_client_does_not_import_worker():
     """The Azure managed client shares the namespace but is client-only."""
+    # The provider is distributed separately and is not installed in every CI
+    # job that runs this suite, so skip rather than fail where it is absent.
+    pytest.importorskip("durabletask.azuremanaged")
     result = _run_python(
         "import sys\n"
         "import durabletask.azuremanaged.client\n"

--- a/tests/durabletask/test_lazy_exports.py
+++ b/tests/durabletask/test_lazy_exports.py
@@ -54,6 +54,21 @@ EAGERLY_IMPORTED_WORKER_MODULES = [
     "durabletask.internal.type_discovery",
 ]
 
+# Submodules that the previous eager imports left bound as attributes of the
+# package as a side effect. A bare ``import durabletask`` must keep them
+# reachable through attribute access alone - without an explicit
+# ``import durabletask.<name>`` - because that was observable behavior before
+# the public exports became lazy.
+EAGERLY_BOUND_SUBMODULES = [
+    "entities",
+    "grpc_options",
+    "internal",
+    "payload",
+    "serialization",
+    "task",
+    "worker",
+]
+
 
 def _run_python(code: str) -> "subprocess.CompletedProcess[str]":
     """Run a snippet in a fresh interpreter so ``sys.modules`` starts clean."""
@@ -176,6 +191,54 @@ def test_submodules_remain_importable_from_the_package():
     result = _run_python(
         "from durabletask import client, entities, task, worker\n"
         "assert task.__name__ == 'durabletask.task'\n"
+    )
+    _assert_ok(result)
+
+
+@pytest.mark.parametrize("name", EAGERLY_BOUND_SUBMODULES)
+def test_submodule_is_reachable_by_attribute_after_a_bare_import(name: str):
+    """``import durabletask`` then ``durabletask.<submodule>`` must still work.
+
+    This is distinct from ``from durabletask import <submodule>``, which
+    succeeds either way because the import system falls back to importing the
+    submodule when ``__getattr__`` raises. Plain attribute access has no such
+    fallback, so the names have to be resolvable through ``__getattr__``.
+    """
+    result = _run_python(
+        "import durabletask\n"
+        f"module = getattr(durabletask, {name!r})\n"
+        f"assert module.__name__ == 'durabletask.{name}', module.__name__\n"
+    )
+    _assert_ok(result)
+
+
+def test_bare_import_does_not_newly_bind_the_client_submodule():
+    """The lazily bound submodules must mirror the old surface, not exceed it.
+
+    ``durabletask.client`` was never pulled in by the previous eager imports,
+    so attribute access on it failed before this change and must keep failing;
+    binding it now would expand the public surface rather than preserve it.
+    """
+    result = _run_python(
+        "import durabletask\n"
+        "try:\n"
+        "    durabletask.client\n"
+        "except AttributeError:\n"
+        "    pass\n"
+        "else:\n"
+        "    raise AssertionError('durabletask.client should not be bound')\n"
+    )
+    _assert_ok(result)
+
+
+def test_attribute_access_to_a_submodule_stays_lazy():
+    """Reaching a submodule by attribute must not happen at package import."""
+    result = _run_python(
+        "import sys\n"
+        "import durabletask\n"
+        "assert 'durabletask.task' not in sys.modules\n"
+        "durabletask.task\n"
+        "assert 'durabletask.task' in sys.modules\n"
     )
     _assert_ok(result)
 

--- a/tests/durabletask/test_lazy_exports.py
+++ b/tests/durabletask/test_lazy_exports.py
@@ -1,0 +1,200 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the lazy public exports of the ``durabletask`` package.
+
+The ``durabletask`` package initializer resolves its public names lazily (PEP
+562) so that importing it - which also happens implicitly when importing
+anything from the ``durabletask.azuremanaged`` distribution, because both share
+the ``durabletask`` namespace - does not pull in the worker dependency graph.
+These tests pin both that behavior and the public surface it has to preserve.
+"""
+
+import importlib
+import subprocess
+import sys
+
+import pytest
+
+import durabletask
+
+EXPECTED_ALL = [
+    "ActivityWorkItemFilter",
+    "ConcurrencyOptions",
+    "EntityWorkItemFilter",
+    "GrpcChannelOptions",
+    "GrpcRetryPolicyOptions",
+    "LargePayloadStorageOptions",
+    "OrchestrationWorkItemFilter",
+    "PayloadStore",
+    "VersioningOptions",
+    "WorkItemFilters",
+]
+
+# Where each public name is actually defined. Declared independently of the
+# package's own lazy-export table so that a wrong mapping is caught rather than
+# mirrored back.
+EXPECTED_SOURCE_MODULES = {
+    "ActivityWorkItemFilter": "durabletask.worker",
+    "ConcurrencyOptions": "durabletask.worker",
+    "EntityWorkItemFilter": "durabletask.worker",
+    "GrpcChannelOptions": "durabletask.grpc_options",
+    "GrpcRetryPolicyOptions": "durabletask.grpc_options",
+    "LargePayloadStorageOptions": "durabletask.payload.store",
+    "OrchestrationWorkItemFilter": "durabletask.worker",
+    "PayloadStore": "durabletask.payload.store",
+    "VersioningOptions": "durabletask.worker",
+    "WorkItemFilters": "durabletask.worker",
+}
+
+# Modules that a client-only application should not have to pay for at import
+# time. ``durabletask.worker`` is the entry point into the rest of them.
+EAGERLY_IMPORTED_WORKER_MODULES = [
+    "durabletask.worker",
+    "durabletask.internal.type_discovery",
+]
+
+
+def _run_python(code: str) -> "subprocess.CompletedProcess[str]":
+    """Run a snippet in a fresh interpreter so ``sys.modules`` starts clean."""
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _assert_ok(result: "subprocess.CompletedProcess[str]") -> None:
+    assert result.returncode == 0, (
+        f"subprocess failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+@pytest.mark.parametrize("module_name", EAGERLY_IMPORTED_WORKER_MODULES)
+def test_importing_package_does_not_import_worker(module_name: str):
+    """A bare ``import durabletask`` must not load the worker graph."""
+    result = _run_python(
+        "import sys\n"
+        "import durabletask\n"
+        f"assert {module_name!r} not in sys.modules, sorted(\n"
+        "    m for m in sys.modules if m.startswith('durabletask')\n"
+        ")\n"
+    )
+    _assert_ok(result)
+
+
+def test_importing_package_does_not_import_grpc_or_protobuf():
+    """The worker's heavyweight third-party dependencies stay unimported."""
+    result = _run_python(
+        "import sys\n"
+        "import durabletask\n"
+        "loaded = [\n"
+        "    name\n"
+        "    for name in ('grpc', 'google.protobuf', 'opentelemetry')\n"
+        "    if name in sys.modules\n"
+        "]\n"
+        "assert not loaded, loaded\n"
+    )
+    _assert_ok(result)
+
+
+def test_importing_azuremanaged_client_does_not_import_worker():
+    """The Azure managed client shares the namespace but is client-only."""
+    result = _run_python(
+        "import sys\n"
+        "import durabletask.azuremanaged.client\n"
+        "assert 'durabletask.worker' not in sys.modules\n"
+    )
+    _assert_ok(result)
+
+
+@pytest.mark.parametrize("name", EXPECTED_ALL)
+def test_public_name_is_importable(name: str):
+    """Every re-exported symbol is still reachable via ``from durabletask``."""
+    result = _run_python(f"from durabletask import {name}\nassert {name} is not None\n")
+    _assert_ok(result)
+
+
+@pytest.mark.parametrize("name", EXPECTED_ALL)
+def test_public_name_is_the_same_object_as_in_its_defining_module(name: str):
+    """Lazy resolution returns the original object, not a copy or proxy."""
+    module = importlib.import_module(EXPECTED_SOURCE_MODULES[name])
+    assert getattr(durabletask, name) is getattr(module, name)
+
+
+def test_all_is_unchanged():
+    assert durabletask.__all__ == EXPECTED_ALL
+
+
+def test_every_public_name_has_a_known_source_module():
+    """``__all__`` and the expected source mapping must not drift apart."""
+    assert sorted(EXPECTED_SOURCE_MODULES) == sorted(EXPECTED_ALL)
+
+
+def test_package_name_is_unchanged():
+    assert durabletask.PACKAGE_NAME == "durabletask"
+
+
+def test_dir_includes_public_names():
+    """``dir()`` reports lazy names even before they have been resolved."""
+    result = _run_python(
+        "import durabletask\n"
+        f"missing = [name for name in {EXPECTED_ALL!r} if name not in dir(durabletask)]\n"
+        "assert not missing, missing\n"
+        "assert 'PACKAGE_NAME' in dir(durabletask)\n"
+        "assert dir(durabletask) == sorted(dir(durabletask))\n"
+    )
+    _assert_ok(result)
+
+
+def test_star_import_binds_all_public_names():
+    result = _run_python(
+        "import durabletask\n"
+        "namespace = {}\n"
+        "exec('from durabletask import *', namespace)\n"
+        "missing = [name for name in durabletask.__all__ if name not in namespace]\n"
+        "assert not missing, missing\n"
+    )
+    _assert_ok(result)
+
+
+def test_unknown_attribute_raises_attribute_error():
+    with pytest.raises(AttributeError) as excinfo:
+        durabletask.ThisAttributeDoesNotExist  # type: ignore[attr-defined]
+
+    assert str(excinfo.value) == (
+        "module 'durabletask' has no attribute 'ThisAttributeDoesNotExist'"
+    )
+
+
+def test_hasattr_is_false_for_unknown_attribute():
+    assert not hasattr(durabletask, "ThisAttributeDoesNotExist")
+
+
+def test_submodules_remain_importable_from_the_package():
+    """``__getattr__`` must not shadow normal submodule imports."""
+    result = _run_python(
+        "from durabletask import client, entities, task, worker\n"
+        "assert task.__name__ == 'durabletask.task'\n"
+    )
+    _assert_ok(result)
+
+
+def test_resolved_name_is_cached_on_the_module():
+    result = _run_python(
+        "import durabletask\n"
+        "assert 'ConcurrencyOptions' not in vars(durabletask)\n"
+        "durabletask.ConcurrencyOptions\n"
+        "assert 'ConcurrencyOptions' in vars(durabletask)\n"
+    )
+    _assert_ok(result)
+
+
+def test_importing_worker_first_does_not_break_the_package():
+    """Guard against an import cycle: ``durabletask.worker`` imports the package."""
+    result = _run_python(
+        "import durabletask.worker\n"
+        "from durabletask import ConcurrencyOptions\n"
+        "assert ConcurrencyOptions is durabletask.worker.ConcurrencyOptions\n"
+    )
+    _assert_ok(result)


### PR DESCRIPTION
## Summary

The `durabletask` package initializer eagerly imported `durabletask.worker` (and `durabletask.payload.store`) purely to re-export a handful of public types. Because `durabletask-azuremanaged/durabletask/` has **no `__init__.py` of its own** — the Azure managed distribution shares the *same* `durabletask` namespace package — importing anything from it (e.g. `durabletask.azuremanaged.client`) first executes the core initializer, and therefore drags in the entire worker dependency graph (gRPC, protobuf, entities, serialization, OpenTelemetry) even for client-only applications.

This PR resolves those public re-exports lazily via a module-level `__getattr__` (PEP 562), paired with a `TYPE_CHECKING` block so static type checkers and IDEs still resolve every symbol. Resolved values are cached into the module globals, so only the *first* attribute access goes through the hook.

All 10 re-exports are made lazy rather than just the worker ones — `durabletask.payload.store` triggers `durabletask/payload/__init__.py`, which imports `payload/helpers.py`, which imports `google.protobuf`. Same amount of code, strictly more benefit.

## Measurements

Re-measured after merging `main` (`2269c44`). The module counts below are unchanged from the earlier measurement, so the packages added by #155, #198, #206, #210 and #211 did not shift the baseline. `python -X importtime`, medians of 9 runs. Times are the **cumulative** column of the module's own `importtime` line — i.e. the cost attributable to the import statement, excluding interpreter startup. Bare interpreter startup on this machine is **93.3 ms / 78 modules**, which is the floor for the module counts.

| Scenario | Before | After | Delta |
| --- | --- | --- | --- |
| `import durabletask` — attributable time | 415.0 ms | **5.7 ms** | ~73x faster |
| `import durabletask` — modules resident | 294 | **82** | **−212 modules** |
| `import durabletask.azuremanaged.client` — attributable time | 716.8 ms | 646.2 ms | ~70 ms |
| `import durabletask.azuremanaged.client` — modules resident | 409 | 399 | −10 modules |

> [!IMPORTANT]
> The headline "415 ms → 5.7 ms" applies to a bare `import durabletask`. The realistic client path, `import durabletask.azuremanaged.client`, improves far less — roughly 70 ms and 10 modules — because that module imports gRPC and protobuf directly for its own purposes, so this change cannot avoid them. The large win accrues to code that imports `durabletask` (or anything under the namespace) *without* needing the worker; the client path benefits only modestly.

Modules no longer loaded by `import durabletask.azuremanaged.client`: `durabletask.worker`, `durabletask.internal.exceptions`, `durabletask.internal.json_encode_output_exception`, `durabletask.internal.orchestration_entity_context`, `durabletask.internal.type_discovery`, `packaging`, `packaging.version`, `queue`, `_queue`, `concurrent.futures.thread`.

> [!NOTE]
> This machine runs many concurrent workloads, so cold-import timings vary by roughly ±10% run to run. The module counts are exact and deterministic, and are the more reliable signal.

### Interaction with #197

#197 makes the same kind of change for the sandboxes preview package. Measuring `import durabletask.azuremanaged.preview.sandboxes` across all four combinations shows the two changes are **super-additive** — neither alone gets close to the combined result. (These figures are totals including the interpreter floor, and were independently reproduced by the #197 author with identical module counts in all four cells.)

| Configuration | Time | Modules |
| --- | --- | --- |
| Neither change | 1018.0 ms | 548 |
| **This PR (#196) alone** | 1040.4 ms | **548 (no change)** |
| #197 alone | 467.5 ms | 296 |
| **Both** | **94.0 ms** | **84** |

To be explicit about what this PR does *not* do: on its own it gives **no improvement** to the sandboxes import path, because `sandboxes/__init__.py` independently imports the worker graph, so that graph loads regardless of what the core initializer does. Symmetrically, #197 alone still pays for the eager core initializer. Only closing both doors avoids loading gRPC/protobuf at all. The two PRs are complementary and independently correct; neither blocks the other, and they touch disjoint files.

## Backwards compatibility

No public API changes. Explicitly preserved and covered by tests:

- Every existing import path: `from durabletask import ConcurrencyOptions, GrpcChannelOptions, GrpcRetryPolicyOptions, LargePayloadStorageOptions, PayloadStore, ActivityWorkItemFilter, EntityWorkItemFilter, OrchestrationWorkItemFilter, VersioningOptions, WorkItemFilters`
- `__all__` verbatim (same names, same order) and `PACKAGE_NAME`
- `dir(durabletask)` still returns the public names (module-level `__dir__` added)
- `from durabletask import *`
- **Submodule attribute access after a bare `import durabletask`** — see below
- Submodule imports (`from durabletask import task, client, worker, entities`) — these keep working because `__getattr__` *raises* `AttributeError`, letting importlib's `_handle_fromlist` fall back to importing the submodule
- The exact `AttributeError` message shape for genuinely unknown attributes
- Each lazily-resolved symbol is the *same object* as in its defining module (identity, not a copy)

No import cycle: `durabletask/worker.py` does `from durabletask import task`, and both import orders (`import durabletask` first, `import durabletask.worker` first) are verified.

### Preserving submodule attribute bindings

The eager `from durabletask.worker import ...` had a second, easily-missed effect: importing a submodule binds it as an attribute of its parent package. So on `main`, a bare `import durabletask` left seven submodules reachable as attributes — `entities`, `grpc_options`, `internal`, `payload`, `serialization`, `task`, `worker` — and code doing `import durabletask` followed by `durabletask.task.X` worked.

Making the re-exports lazy removed that side effect, so those attributes started raising `AttributeError`. This was caught in review and is fixed here by a `_LAZY_SUBMODULES` frozenset that `__getattr__` consults after the export lookup misses, resolving via `import_module(f".{name}", __name__)` and caching the result the same way. The names are also included in `__dir__`.

This stays **fully lazy** — nothing is imported at module load, so the cold-start win is unaffected (re-measured post-merge: 5.7 ms, 82 modules, with `durabletask.worker` and `grpc` still absent from `sys.modules`).

Two details worth noting:

- The seven names were derived empirically from a clean `main` checkout rather than hand-picked, so the restored surface matches exactly.
- `durabletask.client` is deliberately **not** included. It was never transitively imported on `main`, so it already failed this way; adding it would *expand* the public surface rather than preserve it. A test pins that it stays unbound.

A full attribute-surface comparison against `main` confirms nothing is lost.

### Compatibility with the new `azure-functions-durable` package

`main` added the in-repo `azure-functions-durable` package (#155), which imports heavily from this namespace. All 26 of its distinct `durabletask` imports use the explicit `from X import Y` form, which resolves correctly under PEP 562; every other textual `durabletask.` occurrence is a docstring cross-reference or a deprecation message, not runtime attribute access. Verified empirically rather than assumed — its suite returns the **same 202 passed** both with this change and with `main`'s eager initializer.

## CI fix

The first CI run failed on all five Python versions with `ModuleNotFoundError: No module named 'durabletask.azuremanaged'` in `test_importing_azuremanaged_client_does_not_import_worker`.

The cause is a missing package, **not** lazy initialization: the `run-tests` job in `.github/workflows/durabletask.yml` installs `requirements.txt`, `.[azure-blob-payloads]` and `aiohttp`, and never installs `durabletask-azuremanaged`. The test's subprocess could not import the provider there under any implementation; it passed locally only because a development environment has both distributions installed.

Fixed by guarding that one test with `pytest.importorskip("durabletask.azuremanaged")`, so it skips cleanly where the provider is absent and still runs — with its assertion unchanged — wherever it is present. Widening the workflow's install scope seemed out of scope for this PR. Verified by blocking the provider behind a `sys.meta_path` hook to simulate the CI environment: **42 passed / 1 skipped** without the provider, **43 passed** with it.

## Verification

All commands run against a session-local venv with the packages installed editable from this worktree, after merging `main` (`0f316cc`).

| Check | Result |
| --- | --- |
| `pytest tests/durabletask -q --ignore-glob="*_e2e.py"` | **727 passed, 7 skipped** |
| `pytest tests/azure-functions-durable -m "not dts and not azurite and not functions_e2e"` | **202 passed** — identical to the same run against `main`'s eager initializer |
| `pytest tests/durabletask-azuremanaged/test_sandboxes_extension.py tests/durabletask-azuremanaged/test_durabletask_grpc_interceptor.py -q` | **45 passed** |
| `flake8 .` (as the lint job runs it) | clean, exit 0 |
| `pyright` strict on `durabletask/__init__.py` | **0 diagnostics** |
| `pymarkdown -c .pymarkdown.json scan CHANGELOG.md` | 0 findings on the added entry |

New tests in `tests/durabletask/test_lazy_exports.py` (43 tests) cover:

- `durabletask.worker` is **not** in `sys.modules` after a bare `import durabletask` (run in a subprocess for isolation), and likewise for `grpc`, `google.protobuf`, and `opentelemetry`
- The same holds after `import durabletask.azuremanaged.client`
- Each of the seven eagerly-bound submodules resolves by attribute access after a bare `import durabletask`, and does so lazily
- Every public name is importable, resolves to the same object as in its defining module, and its source module is pinned independently of the implementation
- `__all__`, `dir()`, star-import, `PACKAGE_NAME`, `AttributeError` shape, caching, and both import orders

Sanity check that the tests are meaningful: the submodule regression tests were written first and confirmed to **fail** (8 failures) against the unfixed implementation. Likewise, against the original eager initializer the lazy-behavior tests fail while the backwards-compatibility tests pass on both implementations — which is the intended split, since the compat tests pin behavior that must not change.

### Note on the CHANGELOG entry

`CHANGELOG.md` has 16 pre-existing MD013 line-length violations on `main`. The entry added here is wrapped to the 100-character limit using non-indented continuation lines, keeping that count unchanged rather than adding to it. Reflowing the rest of the file seemed out of scope.

Fixes #196

