### PR TITLE
Stabilize Azure Functions Durable E2E tests

### DIFF
--- a/tests/azure-functions-durable/e2e/_markers.py
+++ b/tests/azure-functions-durable/e2e/_markers.py
@@ -1,0 +1,14 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Shared markers for the Azure Functions Durable E2E suite."""
+
+import pytest
+
+
+azurite_delayed_visibility = pytest.mark.skip(
+    reason=(
+        "Azurite intermittently fails to return queue messages after an initial "
+        "visibility delay; see https://github.com/Azure/Azurite/issues/2343."
+    ),
+)

--- a/tests/azure-functions-durable/e2e/apps/dtask_style/history_export_routes.py
+++ b/tests/azure-functions-durable/e2e/apps/dtask_style/history_export_routes.py
@@ -14,10 +14,11 @@ in whatever worker runs them) and use the writer registered at
 ``configure_history_export`` time, so this route no longer binds a process-wide
 context. The route only builds an ``ExportHistoryClient`` for the job-management
 surface (create / get job). A local-filesystem writer sends exported history to
-``<app>/_export_output`` where the test can read it back.
+a temporary directory outside the function app where the test can read it back.
 """
 
 import json
+import tempfile
 from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -44,9 +45,11 @@ from azure.durable_functions.internal.serialization import (
 
 bp = df.Blueprint()
 
-# Exported history is written under the app directory so the E2E test (running
-# on the same machine) can read it back and assert on the contents.
-EXPORT_ROOT = Path(__file__).parent / "_export_output"
+# Keep generated files outside the function app. Writing beneath the app root
+# triggers the Functions host's file watcher and restarts the host mid-suite.
+EXPORT_ROOT = (
+    Path(tempfile.gettempdir()) / "durabletask-python-e2e" / "history-export"
+)
 
 
 class _FileSystemHistoryWriter:

--- a/tests/azure-functions-durable/e2e/test_dtask_entities_advanced_e2e.py
+++ b/tests/azure-functions-durable/e2e/test_dtask_entities_advanced_e2e.py
@@ -14,6 +14,8 @@ import time
 
 import pytest
 
+from ._markers import azurite_delayed_visibility
+
 pytestmark = pytest.mark.functions_e2e
 
 
@@ -80,6 +82,7 @@ def test_call_failing_entity_handled(dtask_app):
     assert status["output"]["caught"] is True
 
 
+@azurite_delayed_visibility
 def test_client_delayed_signal_is_deferred(dtask_app):
     key = f"client-delay-{int(time.time() * 1000)}"
     dtask_app.signal_entity("counter", key, "add", input=9, delay_seconds=3.0)
@@ -96,6 +99,7 @@ def test_client_delayed_signal_is_deferred(dtask_app):
     assert payload["state"] == 9
 
 
+@azurite_delayed_visibility
 def test_orchestration_delayed_signal_is_deferred(dtask_app):
     key = f"orch-delay-{int(time.time() * 1000)}"
     instance_id = dtask_app.start_orchestration("signal_counter_delayed", body=key)

--- a/tests/azure-functions-durable/e2e/test_dtask_patterns_e2e.py
+++ b/tests/azure-functions-durable/e2e/test_dtask_patterns_e2e.py
@@ -13,9 +13,12 @@ from uuid import UUID
 
 import pytest
 
+from ._markers import azurite_delayed_visibility
+
 pytestmark = pytest.mark.functions_e2e
 
 
+@azurite_delayed_visibility
 def test_timer(dtask_app):
     instance_id = dtask_app.start_orchestration("timer_wait")
     status = dtask_app.wait_for_completion(instance_id)

--- a/tests/azure-functions-durable/e2e/test_dtask_scheduled_e2e.py
+++ b/tests/azure-functions-durable/e2e/test_dtask_scheduled_e2e.py
@@ -13,7 +13,12 @@ import time
 
 import pytest
 
-pytestmark = pytest.mark.functions_e2e
+from ._markers import azurite_delayed_visibility
+
+pytestmark = [
+    pytest.mark.functions_e2e,
+    azurite_delayed_visibility,
+]
 
 
 def test_scheduled_orchestration_fires_repeatedly(dtask_app):

--- a/tests/azure-functions-durable/e2e/test_v1_patterns_e2e.py
+++ b/tests/azure-functions-durable/e2e/test_v1_patterns_e2e.py
@@ -13,9 +13,12 @@ from uuid import UUID
 
 import pytest
 
+from ._markers import azurite_delayed_visibility
+
 pytestmark = pytest.mark.functions_e2e
 
 
+@azurite_delayed_visibility
 def test_timer(v1_app):
     instance_id = v1_app.start_orchestration("timer_wait")
     status = v1_app.wait_for_completion(instance_id)


### PR DESCRIPTION
## Summary

- write history-export artifacts to the system temporary directory instead of beneath the Function app, preventing the Functions file watcher from restarting the host mid-suite
- temporarily skip the six E2E checks that directly depend on Azurite returning messages after an initial visibility delay: V1 and durabletask timers, delayed entity signals, and scheduled tasks
- centralize the skip explanation and link it to Azure/Azurite#2343 so the quarantine is easy to remove when emulator behavior is reliable

The AzureStorage polling interval does not address this failure: the failed runs polled after the messages were due, but Azurite returned empty queue responses. Retry-policy E2Es remain enabled because they have not exhibited the failure and use substantially shorter delays.

## Validation

- `python -m flake8` on the changed E2E files
- focused history-export Functions E2E: 2 passed
- full Functions E2E: 74 passed, 7 skipped (six quarantined tests plus the pre-existing Docker-dependent tracing skip)
- confirmed the Functions host log contains no configuration-change restart during history export