### PR TITLE
Prepare durabletask 1.9.0 and Azure Functions 2.0.0b2 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## v1.9.0
+
 ADDED
 
 - Added `OrchestrationContext.send_event()` for replay-safe, one-way event
@@ -26,6 +28,11 @@ export jobs without a synchronous client bridge.
 
 CHANGED
 
+- Improved orchestration and entity execution performance by reducing replay
+allocations, caching handler and entity-method signature metadata, and
+serializing history-export events in a single pass. These changes reduce CPU
+and memory overhead for long histories and high-frequency handlers without
+changing serialized output or handler behavior.
 - Importing `durabletask` no longer eagerly imports the worker implementation and its
 dependencies (gRPC, protobuf, entities, serialization, OpenTelemetry). The public names
 re-exported from the package — `ActivityWorkItemFilter`, `ConcurrencyOptions`,

--- a/azure-functions-durable/CHANGELOG.md
+++ b/azure-functions-durable/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v2.0.0b2
+
 ADDED
 
+- Durabletask-native orchestrations can now use
+`OrchestrationContext.send_event()` for replay-safe, one-way event delivery to
+another orchestration instance.
 - Added PEP 561 type information so strict type checkers recognize
 `azure.durable_functions` as a typed package.
 - Added `azure.durable_functions.testing.execute_entity()` for unit testing
@@ -29,6 +34,13 @@ upgrading from 1.x.
 
 CHANGED
 
+- Updated the minimum `durabletask` dependency to v1.9.0. Its reduced replay
+allocations, cached handler metadata, one-pass history serialization, and
+bounded async work-item task creation improve orchestration and entity
+throughput and memory efficiency for Durable Functions applications.
+- `FailureDetails.error_type` now uses fully-qualified type names, and
+`FailureDetails.is_caused_by()` provides base-type-aware matching. See the core
+`durabletask` changelog for compatibility details.
 - Reused host-driven orchestration and entity workers across invocations,
 avoiding repeated allocation of unused worker resources.
 

--- a/azure-functions-durable/pyproject.toml
+++ b/azure-functions-durable/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "azure-functions-durable"
-version = "2.0.0b1"
+version = "2.0.0b2"
 description = "Durable Task Python SDK provider implementation for Durable Azure Functions"
 keywords = [
     "durable",

--- a/durabletask-azuremanaged/CHANGELOG.md
+++ b/durabletask-azuremanaged/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## v1.9.0
+
+CHANGED
+
+- Updated the base dependency to `durabletask` v1.9.0.
 - `DurableTaskSchedulerClient` and `DurableTaskSchedulerWorker` no longer block on an Azure
   credential round trip while being constructed. The access token is now acquired on the first
   request instead, so constructing a client or worker that is never used costs nothing. As a
@@ -21,6 +26,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Improved async access token refresh concurrency handling to avoid duplicate
   refresh operations under concurrent access, matching the existing sync
   behavior.
+- Improved sandbox worker startup and recovery performance by indexing activity
+  overlap validation, caching SDK version metadata, and reusing the registration
+  transport across transient failures.
+
+FIXED
+
 - Fixed `AsyncDurableTaskSchedulerClient` failing during construction when no
   current event loop was set. Its async gRPC channel is now created on first
   use and bound to the event loop performing the request.

--- a/durabletask-azuremanaged/pyproject.toml
+++ b/durabletask-azuremanaged/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "durabletask.azuremanaged"
-version = "1.8.0"
+version = "1.9.0"
 description = "Durable Task Python SDK provider implementation for the Azure Durable Task Scheduler"
 keywords = [
     "durable",
@@ -26,13 +26,13 @@ requires-python = ">=3.10"
 license = {file = "LICENSE"}
 readme = "README.md"
 dependencies = [
-    "durabletask>=1.8.0",
+    "durabletask>=1.9.0",
     "azure-identity>=1.19.0"
 ]
 
 [project.optional-dependencies]
 azure-blob-payloads = [
-    "durabletask[azure-blob-payloads]>=1.8.0"
+    "durabletask[azure-blob-payloads]>=1.9.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

- prepare `durabletask` 1.9.0, `durabletask.azuremanaged` 1.9.0, and `azure-functions-durable` 2.0.0b2
- move the accumulated unreleased notes under versioned release headings
- add callouts for core replay and serialization performance, Azure Managed sandbox startup and recovery performance, and Azure Functions compatibility and inherited core improvements

## Commit coverage

- `durabletask`: `v1.8.0..HEAD`
- `durabletask.azuremanaged`: `azuremanaged-v1.8.0..HEAD`
- `azure-functions-durable`: `azurefunctions-v2.0.0b1..HEAD`

The Azure Functions range uses the repository's prior package release tag, `azurefunctions-v2.0.0b1`.

## Validation

- parsed all three `pyproject.toml` files and verified package versions and dependency floors
- checked the release headings and final diff formatting