### PR TITLE
Close worker background event loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ import paths, `__all__`, `dir()`, and star-imports behave exactly as before.
 
 FIXED
 
+- Fixed `TaskHubGrpcWorker` leaving its background event loop unclosed after
+shutdown, which could retain resources and emit delayed `ResourceWarning`
+messages.
 - Fixed `AsyncTaskHubGrpcClient` failing during construction when no current
 event loop was set. SDK-owned async gRPC channels are now created on first use,
 binding them to the event loop that performs the RPC.

--- a/durabletask/worker.py
+++ b/durabletask/worker.py
@@ -760,9 +760,7 @@ class TaskHubGrpcWorker:
         self._shutdown.clear()
 
         def run_loop() -> None:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            loop.run_until_complete(self._async_run_loop())
+            asyncio.run(self._async_run_loop())
 
         self._logger.info(f"Starting gRPC worker that connects to {self._host_address}")
         self._runLoop = Thread(target=run_loop)

--- a/tests/durabletask/test_worker_resiliency.py
+++ b/tests/durabletask/test_worker_resiliency.py
@@ -180,6 +180,23 @@ def test_worker_start_clears_prior_shutdown_request():
     worker.stop()
 
 
+def test_worker_start_closes_background_event_loop():
+    worker = TaskHubGrpcWorker()
+    event_loops = []
+
+    async def fake_run_loop():
+        event_loops.append(asyncio.get_running_loop())
+
+    worker._async_run_loop = fake_run_loop
+    worker.start()
+    worker._runLoop.join(timeout=1.0)
+
+    assert len(event_loops) == 1
+    assert event_loops[0].is_closed() is True
+
+    worker.stop()
+
+
 def test_worker_classifies_graceful_close_before_first_message():
     worker = TaskHubGrpcWorker(
         resiliency_options=GrpcWorkerResiliencyOptions(silent_disconnect_timeout_seconds=5.0)


### PR DESCRIPTION
## Why this is needed

`TaskHubGrpcWorker.start()` creates an asyncio event loop on its background thread but never closes it. Stopped workers therefore retain loop resources until cyclic garbage collection, which can emit a delayed `ResourceWarning: unclosed event loop` during unrelated code.

This surfaced as the intermittent Python 3.11 failure in PR #252 when garbage collection ran inside a warning-capture block.

## Changes

- use `asyncio.run()` to own and close the worker thread's event loop
- add deterministic regression coverage that retains the loop and verifies it is closed after the thread exits
- document the resource leak fix in the core changelog

## Validation

- `python -m pytest tests\durabletask\test_worker_resiliency.py tests\durabletask\test_worker_concurrency_loop.py tests\durabletask\test_worker_concurrency_loop_async.py --quiet`
- `python -m nox -s core_tests-3.11 -- tests\durabletask\test_worker_resiliency.py -k worker_start --quiet`
- `python -m flake8 durabletask`
- `python -m flake8 tests\durabletask`