### PR TITLE
Prepare durabletask 1.10.0 and Azure Functions 2.0.0b3 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## v1.10.0
+
 ADDED
 
 - Added a `logger` parameter to `TaskHubGrpcClient`,
@@ -36,6 +38,12 @@ CHANGED
 `TaskHubGrpcClient`, `AsyncTaskHubGrpcClient`, and `TaskHubGrpcWorker`.
 Configure and pass a `logger` instead. These parameters will be removed in a
 future major release.
+
+FIXED
+
+- Fixed `TaskHubGrpcWorker` leaving its background event loop unclosed after
+shutdown, which could retain resources and emit delayed `ResourceWarning`
+messages.
 
 ## v1.9.0
 
@@ -78,9 +86,6 @@ import paths, `__all__`, `dir()`, and star-imports behave exactly as before.
 
 FIXED
 
-- Fixed `TaskHubGrpcWorker` leaving its background event loop unclosed after
-shutdown, which could retain resources and emit delayed `ResourceWarning`
-messages.
 - Fixed `AsyncTaskHubGrpcClient` failing during construction when no current
 event loop was set. SDK-owned async gRPC channels are now created on first use,
 binding them to the event loop that performs the RPC.

--- a/azure-functions-durable/CHANGELOG.md
+++ b/azure-functions-durable/CHANGELOG.md
@@ -7,29 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v2.0.0b3
+
 ADDED
 
 - Added an optional timeout to filtered orchestration purges through
 `DurableFunctionsClient` and `SyncDurableFunctionsClient`.
 - Added inherited `OrchestrationQuery.instance_id_prefix` support to retrieve
 orchestration instances whose IDs begin with a specified prefix.
-> [!NOTE]
-> Release this change only in coordination with a new `durabletask` release
-> that contains the suspend/resume reason APIs. Publish `durabletask` first,
-> then update this package's minimum dependency in its dedicated release PR.
+
+CHANGED
+
+- Updated the minimum `durabletask` dependency to v1.10.0.
+- Durable Functions client and worker logs now use the Azure Functions
+host-managed `azure.durable_functions` logger hierarchy instead of private SDK
+handlers. Configure their level, destination, and telemetry routing through the
+standard Functions/Python logging configuration.
+- Updated the v2 migration guidance and samples to use the public Azure
+Functions extension bundle, which now includes an AFD v2-compatible extension.
 
 FIXED
 
 - Fixed deprecated `DurableFunctionsClient.suspend()` and `resume()` methods
 discarding their `reason` arguments. Reasons are now forwarded to the Durable
 Task backend.
-
-CHANGED
-
-- Durable Functions client and worker logs now use the Azure Functions
-host-managed `azure.durable_functions` logger hierarchy instead of private SDK
-handlers. Configure their level, destination, and telemetry routing through the
-standard Functions/Python logging configuration.
 
 ## v2.0.0b2
 

--- a/azure-functions-durable/pyproject.toml
+++ b/azure-functions-durable/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "azure-functions-durable"
-version = "2.0.0b2"
+version = "2.0.0b3"
 description = "Durable Task Python SDK provider implementation for Durable Azure Functions"
 keywords = [
     "durable",
@@ -27,7 +27,7 @@ requires-python = ">=3.13"
 license = {file = "LICENSE"}
 readme = "README.md"
 dependencies = [
-    "durabletask[opentelemetry]>=1.9.0",
+    "durabletask[opentelemetry]>=1.10.0",
     "azure-identity>=1.19.0",
     "azure-functions>=2.3.0b2"
 ]

--- a/durabletask-azuremanaged/CHANGELOG.md
+++ b/durabletask-azuremanaged/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## v1.10.0
+
 ADDED
 
 - Added a `logger` parameter to `DurableTaskSchedulerClient`,
@@ -25,6 +27,7 @@ from `TaskHubGrpcClient` and `AsyncTaskHubGrpcClient`.
 
 CHANGED
 
+- Updated the base dependency to `durabletask` v1.10.0.
 - Deprecated the `log_handler` and `log_formatter` parameters on
 `DurableTaskSchedulerClient`, `AsyncDurableTaskSchedulerClient`, and
 `DurableTaskSchedulerWorker`. Configure and pass a `logger` instead. These

--- a/durabletask-azuremanaged/pyproject.toml
+++ b/durabletask-azuremanaged/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "durabletask.azuremanaged"
-version = "1.9.0"
+version = "1.10.0"
 description = "Durable Task Python SDK provider implementation for the Azure Durable Task Scheduler"
 keywords = [
     "durable",
@@ -26,13 +26,13 @@ requires-python = ">=3.10"
 license = {file = "LICENSE"}
 readme = "README.md"
 dependencies = [
-    "durabletask>=1.9.0",
+    "durabletask>=1.10.0",
     "azure-identity>=1.19.0"
 ]
 
 [project.optional-dependencies]
 azure-blob-payloads = [
-    "durabletask[azure-blob-payloads]>=1.9.0"
+    "durabletask[azure-blob-payloads]>=1.10.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "durabletask"
-version = "1.9.0"
+version = "1.10.0"
 description = "A Durable Task Client SDK for Python"
 keywords = [
     "durable",


### PR DESCRIPTION
## Summary

- prepare `durabletask` 1.10.0 and `durabletask.azuremanaged` 1.10.0
- prepare `azure-functions-durable` 2.0.0b3
- update provider dependency floors to `durabletask` 1.10.0
- move accumulated unreleased notes under versioned release headings
- move the worker event-loop fix from the previously released 1.9.0 section into 1.10.0

## Commit coverage

- `durabletask`: `v1.9.0..HEAD`
- `durabletask.azuremanaged`: `azuremanged-v1.9.0..HEAD`
- `azure-functions-durable`: `azurefunctions-v2.0.0b2..HEAD`

The Azure Managed range uses the repository's existing misspelled package tag, `azuremanged-v1.9.0`.

## Validation

- parsed all three `pyproject.toml` files and verified package versions and dependency floors
- checked the release headings and final diff formatting
- confirmed the release-prep diff contains only the six package metadata and changelog files