### PR TITLE
Add repository service metadata

### DIFF
--- a/es-metadata.yml
+++ b/es-metadata.yml
@@ -1,0 +1,12 @@
+schemaVersion: 1.0.0
+providers:
+- provider: InventoryAsCode
+  version: 1.0.0
+  metadata:
+    isProduction: true
+    accountableOwners:
+      service: a45bac48-a99c-4628-abbb-49725dd92796
+    routing:
+      defaultAreaPath:
+        org: azfunc
+        path: internal\DurableTask


### PR DESCRIPTION
## Summary

- add the root `es-metadata.yml` InventoryAsCode manifest
- assign accountability to service `a45bac48-a99c-4628-abbb-49725dd92796`
- retain the Durable SDK routing used by the .NET, Java, and JavaScript repositories

## Validation

- parsed the manifest as YAML
- compared its structure with `microsoft/durabletask-dotnet`, `microsoft/durabletask-java`, and `microsoft/durabletask-js`