### PR TITLE
Prepare durabletask 1.10.1 and Azure Functions 2.0.0rc1 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## v1.10.1
+
 FIXED
 
 - Activity tags, including `durabletask.displayName`, are now preserved across

--- a/azure-functions-durable/CHANGELOG.md
+++ b/azure-functions-durable/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v2.0.0rc1
+
+CHANGED
+
+- Updated the minimum `durabletask` dependency to v1.10.1.
+
 ## v2.0.0b3
 
 ADDED

--- a/azure-functions-durable/pyproject.toml
+++ b/azure-functions-durable/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "azure-functions-durable"
-version = "2.0.0b3"
+version = "2.0.0rc1"
 description = "Durable Task Python SDK provider implementation for Durable Azure Functions"
 keywords = [
     "durable",
@@ -27,7 +27,7 @@ requires-python = ">=3.13"
 license = {file = "LICENSE"}
 readme = "README.md"
 dependencies = [
-    "durabletask[opentelemetry]>=1.10.0",
+    "durabletask[opentelemetry]>=1.10.1",
     "azure-identity>=1.19.0",
     "azure-functions>=2.3.0b2"
 ]

--- a/durabletask-azuremanaged/CHANGELOG.md
+++ b/durabletask-azuremanaged/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## v1.10.1
+
+CHANGED
+
+- Updated the base dependency to `durabletask` v1.10.1.
+
 ## v1.10.0
 
 ADDED

--- a/durabletask-azuremanaged/pyproject.toml
+++ b/durabletask-azuremanaged/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "durabletask.azuremanaged"
-version = "1.10.0"
+version = "1.10.1"
 description = "Durable Task Python SDK provider implementation for the Azure Durable Task Scheduler"
 keywords = [
     "durable",
@@ -26,13 +26,13 @@ requires-python = ">=3.10"
 license = {file = "LICENSE"}
 readme = "README.md"
 dependencies = [
-    "durabletask>=1.10.0",
+    "durabletask>=1.10.1",
     "azure-identity>=1.19.0"
 ]
 
 [project.optional-dependencies]
 azure-blob-payloads = [
-    "durabletask[azure-blob-payloads]>=1.10.0"
+    "durabletask[azure-blob-payloads]>=1.10.1"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "durabletask"
-version = "1.10.0"
+version = "1.10.1"
 description = "A Durable Task Client SDK for Python"
 keywords = [
     "durable",


### PR DESCRIPTION
## Summary

- prepare `durabletask` 1.10.1 and `durabletask.azuremanaged` 1.10.1
- prepare `azure-functions-durable` 2.0.0rc1
- update provider dependency floors to `durabletask` 1.10.1
- move the accumulated core fix under the 1.10.1 release heading

## Commit coverage

- `durabletask`: `v1.10.0..HEAD`
- `durabletask.azuremanaged`: `azuremanaged-v1.10.0..HEAD`
- `azure-functions-durable`: `azurefunctions-v2.0.0b3..HEAD`

The only post-release user-facing change is the core fix that preserves activity tags across retry attempts. The provider release notes record their updated `durabletask` dependency floors.

## Validation

- parsed all three `pyproject.toml` files and verified package versions and dependency floors
- checked the release headings and final diff formatting
- confirmed the release-prep diff contains only the six package metadata and changelog files